### PR TITLE
Freeze GroupTabs at Top of Page

### DIFF
--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -4,6 +4,9 @@
   color: white;
   display: flex;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
 
 ul {


### PR DESCRIPTION
## Summary

This small change updates the GroupTabs (navigation) component's CSS styling so the tabs remain at the top of the page even when scrolling vertically through a list of dials. This closes Issue #4.

I played around with some relative positioning but it ended up affecting multiple components including <App> and Body. Using the `position: sticky` attribute was the simplest solution without altering the flow of elements on the page.

## Changes

- Updates `groupTabs.css` so the Group Tabs have `position: sticky` and `top: 0` to keep it at the top of the page.
- Same component updated with `z-index: 100` so the Group Tabs are visible above dials as the page scrolls.