### PR TITLE
Fix Tab Highlighting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="style.css" />
     <title>New Tab</title>
   </head>
   <body>

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -10,9 +10,11 @@ function useApp() {
   };
 
   const updateGroupIndex = (newIndex) => {
-    const newConfig = { ...config, groupIndex: newIndex };
-    setDialsVisibility(false);
-    updateConfig(newConfig);
+    if (newIndex !== config.groupIndex) {
+      const newConfig = { ...config, groupIndex: newIndex };
+      setDialsVisibility(false);
+      updateConfig(newConfig);
+    }
   };
 
   const getData = async (configUrl) => {

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -13,7 +13,7 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   }
 
   function handleClick({ target }) {
-    const liElement = target.closest('li[data-index');
+    const liElement = target.closest("li[data-index]");
     if (liElement) {
       updateGroupIndex(liElement.dataset.index);
     }

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -1,9 +1,6 @@
 import "./groupTabs.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  // faArrowRotateRight,
-  faEllipsisVertical,
-} from "@fortawesome/free-solid-svg-icons";
+import { faEllipsisVertical } from "@fortawesome/free-solid-svg-icons";
 import Settings from "../Settings/Settings";
 
 function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
@@ -16,7 +13,10 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   }
 
   function handleClick({ target }) {
-    updateGroupIndex(target.dataset.index);
+    const liElement = target.closest('li[data-index');
+    if (liElement) {
+      updateGroupIndex(liElement.dataset.index);
+    }
   }
 
   return (
@@ -41,7 +41,7 @@ function GroupTabs({ groups, groupIndex, updateGroupIndex }) {
             <GroupTab
               group={group}
               idx={idx}
-              isSelected={groupIndex === idx}
+              isSelected={idx === parseInt(groupIndex)}
               updateGroupIndex={updateGroupIndex}
             />
           );


### PR DESCRIPTION
## Summary

This closes Issue #5. The aim of this issue was to fix some CSS styling that highlights the currently selected tab. This was previously working and broke without notice when making further updates (hint, you need to start writing basic rendering tests soon).

A couple issues were going on but the result fixed more than I had aimed for. The main issue is that I was comparing a string (from the config file) and an integer (from the map) using strict equality to determine the currently selected tab. Explicitly coercing the string to an integer before comparison fixed the issue and has sparked an interest in reconsidering TypeScript to help ensure props are received as expected.

I was also able to determine that the the horizontal option icon added to the currently selected tab was causing an error because it didn't have the `data-index` attribute that the tab contains. I had a convo with CoPilot and it was recommended to use the `event.target.closest()` function which takes in a string for a parent element you are searching for, in my case `'li[data-index]'` and returns that element if found.

Finally, I made sure the fade animations don't trigger if you click on the same tab more than once consecutively. 

## Changes
- Removed reference to an unused stylesheet.
- `updateGroupIndex` now ensures the new index differs before updating.
- `GroupTabs` coerces the `config.groupIndex` value to an integer before comparison.
- `handleClick` for `GroupTab` now searches for the closest `li` containing a `data-index` attribute in its ancestry.