### PR TITLE
Basic Settings Page

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,16 +1,39 @@
 import "./App.css";
 import useApp from "./useApp";
 import GroupTabs from "../GroupTabs/GroupTabs";
+import { Settings } from "../Settings/Settings";
 import Time from "../Time/Time";
 import DialGroup from "../Dials/DialGroup";
 
 function App() {
-  const { config, updateGroupIndex, dialsVisibility, setDialsVisibility } =
-    useApp();
+  const {
+    config,
+    getData,
+    updateGroupIndex,
+    dialsVisibility,
+    setDialsVisibility,
+    showSettings,
+    setShowSettings,
+  } = useApp();
 
   function setBackgroundImg() {
     const bodyEl = document.getElementById("App");
     bodyEl.style.backgroundImage = `url('${config.background}')`;
+  }
+
+  function mainContent() {
+    return (
+      <>
+        <Time />
+        {config && config.dialGroups ? (
+          <DialGroup
+            {...config.dialGroups[config.groupIndex]}
+            dialVisibility={dialsVisibility}
+            setDialVisibility={setDialsVisibility}
+          />
+        ) : null}
+      </>
+    );
   }
 
   return (
@@ -21,16 +44,15 @@ function App() {
           groups={config.dialGroups}
           groupIndex={config.groupIndex}
           updateGroupIndex={updateGroupIndex}
+          showSettings={showSettings}
+          setShowSettings={setShowSettings}
         />
       ) : null}
-      <Time />
-      {config && config.dialGroups ? (
-        <DialGroup
-          {...config.dialGroups[config.groupIndex]}
-          dialVisibility={dialsVisibility}
-          setDialVisibility={setDialsVisibility}
-        />
-      ) : null}
+      {showSettings ? (
+        <Settings configUrl={config.configUrl} getData={getData} />
+      ) : (
+        mainContent()
+      )}
     </div>
   );
 }

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 function useApp() {
   const [config, setConfig] = useState(null);
   const [dialsVisibility, setDialsVisibility] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   const updateConfig = (newConfigObj) => {
     localStorage.setItem("dialer-config", JSON.stringify(newConfigObj));
@@ -21,6 +22,7 @@ function useApp() {
     try {
       const response = await fetch(configUrl);
       const parsedConfig = await response.json();
+      // TODO: Add validation of the retrieved config here; Joi too much?
       parsedConfig.configUrl = configUrl;
       updateConfig(parsedConfig);
     } catch (error) {
@@ -34,11 +36,19 @@ function useApp() {
       setConfig(JSON.parse(savedConfig));
     } else {
       const configUrl = window.prompt("URL to JSON config file:");
-      getData(configUrl, setConfig);
+      getData(configUrl);
     }
   }, []);
 
-  return { config, updateGroupIndex, dialsVisibility, setDialsVisibility };
+  return {
+    config,
+    getData,
+    updateGroupIndex,
+    dialsVisibility,
+    setDialsVisibility,
+    showSettings,
+    setShowSettings,
+  };
 }
 
 export default useApp;

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -1,7 +1,7 @@
 import "./groupTabs.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEllipsisVertical } from "@fortawesome/free-solid-svg-icons";
-import Settings from "../Settings/Settings";
+import { SettingsIcon } from "../Settings/Settings";
 
 function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   function TabOptions() {
@@ -32,7 +32,13 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   );
 }
 
-function GroupTabs({ groups, groupIndex, updateGroupIndex }) {
+function GroupTabs({
+  groups,
+  groupIndex,
+  updateGroupIndex,
+  showSettings,
+  setShowSettings,
+}) {
   return (
     <div id="GroupTabs">
       <ul>
@@ -49,7 +55,10 @@ function GroupTabs({ groups, groupIndex, updateGroupIndex }) {
       </ul>
       <ul>
         <li>
-          <Settings />
+          <SettingsIcon
+            showSettings={showSettings}
+            setShowSettings={setShowSettings}
+          />
         </li>
       </ul>
     </div>

--- a/src/Settings/Settings.css
+++ b/src/Settings/Settings.css
@@ -1,0 +1,20 @@
+h1 {
+  color: white;
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+
+h2 {
+  color: white;
+  font-size: 16px;
+  margin-bottom: 5px;
+}
+
+#config-url {
+  width: 33%;
+}
+
+.refresh-icon {
+  color: white;
+  margin-left: 5px;
+}

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -1,8 +1,45 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGear } from "@fortawesome/free-solid-svg-icons";
+import { faGear, faRefresh } from "@fortawesome/free-solid-svg-icons";
+import { useState } from "react";
 
-function Settings() {
-  return <FontAwesomeIcon icon={faGear} />;
+import "./Settings.css";
+
+export function SettingsIcon({ showSettings, setShowSettings }) {
+  function handleClick() {
+    setShowSettings(!showSettings);
+  }
+  return <FontAwesomeIcon onClick={handleClick} icon={faGear} />;
 }
 
-export default Settings;
+export function Settings({ configUrl, getData }) {
+  const [urlInputValue, setUrlInputValue] = useState(configUrl);
+
+  const handleConfigRefresh = () => {
+    const newUrl = document.getElementById("config-url");
+    getData(newUrl.value);
+  };
+
+  const handleUrlChange = () => {
+    const current = document.getElementById("config-url").value;
+    setUrlInputValue(current);
+  };
+
+  return (
+    <>
+      <h1>Settings</h1>
+      <h2>Config File URL</h2>
+      <input
+        type="text"
+        label="configURL"
+        id="config-url"
+        value={urlInputValue}
+        onChange={handleUrlChange}
+      />
+      <FontAwesomeIcon
+        onClick={handleConfigRefresh}
+        icon={faRefresh}
+        className="refresh-icon"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This ticket was to scaffold out a basic Settings page that is shown and hidden when clicking on the Settings gear. This also added a simple initial setting of the config URL and a refresh button to perform a downstream sync.

## Changes

- Updated `App` to render either the main content of the app or the settings page. (this may need to be updated in the future but I really want to avoid using Router on a simple app like this)
- Added a `showSettings` value to `App` state.
- `GroupTabs` updated so the settings gear renders the Settings component.
- Added basic Settings component page and styling.
- Added an input and refresh button to `Settings` to allow for a config URL to be entered and then used in a downstream sync of the config to `localStorage`.