### PR TITLE
Modifies Settings Tab Behavior

### DIFF
--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -1,7 +1,7 @@
 import "./groupTabs.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEllipsisVertical } from "@fortawesome/free-solid-svg-icons";
-import { SettingsIcon } from "../Settings/Settings";
+import { SettingsTab } from "../Settings/Settings";
 
 function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   function TabOptions() {
@@ -41,7 +41,7 @@ function GroupTabs({
 }) {
   return (
     <div id="GroupTabs">
-      <ul>
+      <ul className={showSettings ? "hide-tabs" : ""}>
         {groups.map((group, idx) => {
           return (
             <GroupTab
@@ -53,14 +53,10 @@ function GroupTabs({
           );
         })}
       </ul>
-      <ul>
-        <li>
-          <SettingsIcon
-            showSettings={showSettings}
-            setShowSettings={setShowSettings}
-          />
-        </li>
-      </ul>
+      <SettingsTab
+        showSettings={showSettings}
+        setShowSettings={setShowSettings}
+      />
     </div>
   );
 }

--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -34,3 +34,7 @@ ul li {
   display: inline;
   margin: 0 5px 0 10px;
 }
+
+.hide-tabs {
+  visibility: hidden;
+}

--- a/src/Settings/Settings.css
+++ b/src/Settings/Settings.css
@@ -18,3 +18,7 @@ h2 {
   color: white;
   margin-left: 5px;
 }
+
+.close-attention {
+  background-color: rgba(255, 105, 105, 0.5);
+}

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -1,14 +1,27 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGear, faRefresh } from "@fortawesome/free-solid-svg-icons";
+import {
+  faGear,
+  faRectangleXmark,
+  faRefresh,
+} from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 
 import "./Settings.css";
 
-export function SettingsIcon({ showSettings, setShowSettings }) {
+export function SettingsTab({ showSettings, setShowSettings }) {
   function handleClick() {
     setShowSettings(!showSettings);
   }
-  return <FontAwesomeIcon onClick={handleClick} icon={faGear} />;
+  return (
+    <ul>
+      <li className={showSettings ? "close-attention" : ""}>
+        <FontAwesomeIcon
+          onClick={handleClick}
+          icon={showSettings ? faRectangleXmark : faGear}
+        />
+      </li>
+    </ul>
+  );
 }
 
 export function Settings({ configUrl, getData }) {


### PR DESCRIPTION
## Summary

This ticket was for a few UI tweaks/behavior when the Settings gear is clicked. This closes Issue #12.

## Changes

- Renamed the `SettingsIcon` component to `SettingsTab` to make it more clear. Also moved the `ul` and `li` associated with that tab into the component itself.
- Found an `faRectableXmark` icon on Font Awesome to use when the Settings page is open so there is indication on what action to take to close the Settings page.
- Updated `GroupTabs` so the tabs for dial groups are `visible: hidden` when the Setting page is open.
