### PR TITLE
Clock/Time Settings

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -27,7 +27,7 @@ function App() {
 
     return (
       <>
-        {config.timeEnabled ? <Time /> : null}
+        {config.timeEnabled ? <Time timeFormat={config.timeFormat} /> : null}
         {config.dialGroups ? (
           <DialGroup
             {...config.dialGroups[config.groupIndex]}

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -14,6 +14,7 @@ function App() {
     setDialsVisibility,
     showSettings,
     setShowSettings,
+    updateSetting,
   } = useApp();
 
   function setBackgroundImg() {
@@ -22,10 +23,12 @@ function App() {
   }
 
   function mainContent() {
+    if (!config) return;
+
     return (
       <>
-        <Time />
-        {config && config.dialGroups ? (
+        {config.timeEnabled ? <Time /> : null}
+        {config.dialGroups ? (
           <DialGroup
             {...config.dialGroups[config.groupIndex]}
             dialVisibility={dialsVisibility}
@@ -49,7 +52,12 @@ function App() {
         />
       ) : null}
       {showSettings ? (
-        <Settings configUrl={config.configUrl} getData={getData} />
+        <Settings
+          config={config}
+          configUrl={config.configUrl}
+          getData={getData}
+          updateSetting={updateSetting}
+        />
       ) : (
         mainContent()
       )}

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -5,6 +5,11 @@ function useApp() {
   const [dialsVisibility, setDialsVisibility] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
 
+  const updateSetting = (settingName, settingValue) => {
+    const newConfig = { ...config, [settingName]: settingValue };
+    updateConfig(newConfig);
+  };
+
   const updateConfig = (newConfigObj) => {
     localStorage.setItem("dialer-config", JSON.stringify(newConfigObj));
     setConfig(newConfigObj);
@@ -48,6 +53,7 @@ function useApp() {
     setDialsVisibility,
     showSettings,
     setShowSettings,
+    updateSetting,
   };
 }
 

--- a/src/Settings/Settings.css
+++ b/src/Settings/Settings.css
@@ -14,6 +14,11 @@ h2 {
   width: 33%;
 }
 
+#Settings {
+  font-family: monospace;
+  color: white;
+}
+
 .refresh-icon {
   color: white;
   margin-left: 5px;

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -56,6 +56,7 @@ export function Settings({ config, configUrl, getData, updateSetting }) {
       />
       <TimeSettings
         timeEnabled={config.timeEnabled}
+        timeFormat={config.timeFormat}
         updateSetting={updateSetting}
       />
     </div>

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -7,6 +7,7 @@ import {
 import { useState } from "react";
 
 import "./Settings.css";
+import { TimeSettings } from "./TimeSettings/TimeSettings";
 
 export function SettingsTab({ showSettings, setShowSettings }) {
   function handleClick() {
@@ -24,7 +25,7 @@ export function SettingsTab({ showSettings, setShowSettings }) {
   );
 }
 
-export function Settings({ configUrl, getData }) {
+export function Settings({ config, configUrl, getData, updateSetting }) {
   const [urlInputValue, setUrlInputValue] = useState(configUrl);
 
   const handleConfigRefresh = () => {
@@ -38,7 +39,7 @@ export function Settings({ configUrl, getData }) {
   };
 
   return (
-    <>
+    <div id="Settings">
       <h1>Settings</h1>
       <h2>Config File URL</h2>
       <input
@@ -53,6 +54,10 @@ export function Settings({ configUrl, getData }) {
         icon={faRefresh}
         className="refresh-icon"
       />
-    </>
+      <TimeSettings
+        timeEnabled={config.timeEnabled}
+        updateSetting={updateSetting}
+      />
+    </div>
   );
 }

--- a/src/Settings/TimeSettings/TimeSettings.css
+++ b/src/Settings/TimeSettings/TimeSettings.css
@@ -1,0 +1,3 @@
+select {
+  margin-left: 5px;
+}

--- a/src/Settings/TimeSettings/TimeSettings.js
+++ b/src/Settings/TimeSettings/TimeSettings.js
@@ -1,21 +1,40 @@
-export function TimeSettings({ timeEnabled, updateSetting }) {
+import "./TimeSettings.css";
+
+export function TimeSettings({ timeEnabled, timeFormat, updateSetting }) {
   const updateTimeEnabled = (event) => {
     const newValue = event.target.value === "true" ? true : false;
     updateSetting("timeEnabled", newValue);
   };
-  const currentValue = timeEnabled ? "true" : "false";
+  const updateTimeFormat = (event) => {
+    updateSetting("timeFormat", event.target.value);
+  };
+  const currentDisplay = timeEnabled ? "true" : "false";
+  const currentFormat = timeFormat === "24" ? "24" : "12";
 
   return (
     <div id="TimeSettings">
-      <label for="time-enabled">Show Time</label>
-      <select
-        name="time-enable"
-        value={currentValue}
-        onChange={updateTimeEnabled}
-      >
-        <option value="true">Show</option>
-        <option value="false">Hide</option>
-      </select>
+      <div>
+        <label for="time-enabled">Show Time</label>
+        <select
+          name="time-enable"
+          value={currentDisplay}
+          onChange={updateTimeEnabled}
+        >
+          <option value="true">Show</option>
+          <option value="false">Hide</option>
+        </select>
+      </div>
+      <div>
+        <label for="time-format">Time Format</label>
+        <select
+          name="time-format"
+          value={currentFormat}
+          onChange={updateTimeFormat}
+        >
+          <option value="12">12 Hour</option>
+          <option value="24">24 Hour</option>
+        </select>
+      </div>
     </div>
   );
 }

--- a/src/Settings/TimeSettings/TimeSettings.js
+++ b/src/Settings/TimeSettings/TimeSettings.js
@@ -1,0 +1,21 @@
+export function TimeSettings({ timeEnabled, updateSetting }) {
+  const updateTimeEnabled = (event) => {
+    const newValue = event.target.value === "true" ? true : false;
+    updateSetting("timeEnabled", newValue);
+  };
+  const currentValue = timeEnabled ? "true" : "false";
+
+  return (
+    <div id="TimeSettings">
+      <label for="time-enabled">Show Time</label>
+      <select
+        name="time-enable"
+        value={currentValue}
+        onChange={updateTimeEnabled}
+      >
+        <option value="true">Show</option>
+        <option value="false">Hide</option>
+      </select>
+    </div>
+  );
+}

--- a/src/Time/Time.js
+++ b/src/Time/Time.js
@@ -1,8 +1,8 @@
 import "./time.css";
 import useTime from "./useTime";
 
-function Time() {
-  const { ready, time } = useTime();
+function Time({ timeFormat }) {
+  const { ready, time } = useTime(timeFormat);
 
   return (
     <div className={`time ${ready ? "ready" : ""}`}>

--- a/src/Time/useTime.js
+++ b/src/Time/useTime.js
@@ -1,12 +1,19 @@
 import { useEffect, useState } from "react";
 
-function useTime() {
+function useTime(timeFormat) {
   const [ready, setReady] = useState(false);
   const [time, setTime] = useState("00:00");
 
   useEffect(() => {
     const updateInterval = setInterval(() => {
-      setTime(new Date().toLocaleTimeString("en-GB").slice(0, -3));
+      let timeString = "";
+      if (timeFormat !== "24") {
+        let rawTimeString = new Date().toLocaleTimeString("en-US");
+        timeString = `${rawTimeString.slice(0, -6)} ${rawTimeString.slice(-2)}`;
+      } else {
+        timeString = new Date().toLocaleTimeString("en-GB").slice(0, -3);
+      }
+      setTime(timeString);
       setReady(true);
     }, 1000);
     return () => clearInterval(updateInterval);


### PR DESCRIPTION
## Summary 

This ticket addresses Issue #16, which requested a few basic clock/time settings by adding their controls to the Settings component and then rendering the Time component accordingly.

## Changes
- Created an `updateSetting` function to pass down to children components so they can update top-level settings by passing a name and value.
- Added `timeEnabled` and `timeFormat` values to the config if they are set.
- Changed all references from "Clock" to "Time"
- Created a TimeSettings component to hold related settings and logic. (I should do the same for config settings as they expand)
- Used some conditional logic to chop time strings that are converted to locale time strings, British for 24 hour and US for 12 hour.