### PR TITLE
ISSU-6 Adds tab options menu on click

### DIFF
--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -1,13 +1,21 @@
-import "./groupTabs.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEllipsisVertical } from "@fortawesome/free-solid-svg-icons";
+import { faAnglesDown, faAnglesUp } from "@fortawesome/free-solid-svg-icons";
+import { useState } from "react";
+
+import "./groupTabs.css";
+import TabMenu from "./TabMenu/TabMenu";
 import { SettingsTab } from "../Settings/Settings";
 
 function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
-  function TabOptions() {
+  const [showTabMenu, setShowTabMenu] = useState(false);
+
+  function TabOptions({ onClick }) {
     return (
-      <div className="tabOptions">
-        <FontAwesomeIcon icon={faEllipsisVertical} />
+      <div className="tabOptions" onClick={onClick}>
+        <FontAwesomeIcon
+          className="fa-sm"
+          icon={showTabMenu ? faAnglesUp : faAnglesDown}
+        />
       </div>
     );
   }
@@ -19,6 +27,15 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
     }
   }
 
+  function openMenu(event) {
+    event.stopPropagation();
+    setShowTabMenu(true);
+  }
+
+  function closeMenu() {
+    setShowTabMenu(false);
+  }
+
   return (
     <li
       className={isSelected ? "selectedGroup" : ""}
@@ -27,7 +44,8 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
       onClick={handleClick}
     >
       {group.groupName}
-      {isSelected ? <TabOptions /> : ""}
+      {isSelected && <TabOptions onClick={openMenu} />}
+      {showTabMenu && <TabMenu onClose={closeMenu} />}
     </li>
   );
 }

--- a/src/GroupTabs/TabMenu/TabMenu.css
+++ b/src/GroupTabs/TabMenu/TabMenu.css
@@ -1,0 +1,29 @@
+.tabMenu {
+  position: absolute;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  top: 40px;
+  left: 0;
+}
+
+.tabMenu ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
+}
+
+.tabMenu li {
+  top: 0;
+  border: none;
+  margin: 5px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.tabMenu li:hover {
+  background-color: #f0f0f05b;
+}

--- a/src/GroupTabs/TabMenu/TabMenu.js
+++ b/src/GroupTabs/TabMenu/TabMenu.js
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+
+import "./TabMenu.css";
+
+function TabMenu({ onClose }) {
+  const menuRef = useRef(null);
+
+  // TODO: Remove this
+  const mockFunctionality = (name) => {
+    console.log(`${name} was selected`);
+    if (menuRef.current) menuRef.current.blur();
+  };
+
+  useEffect(() => {
+    if (menuRef.current) {
+      menuRef.current.focus();
+    }
+  });
+
+  return (
+    <div ref={menuRef} className="tabMenu" onBlur={onClose} tabIndex={0}>
+      <ul>
+        <li onClick={() => mockFunctionality("Add")}>Add</li>
+        <li onClick={() => mockFunctionality("Mopdify")}>Modify</li>
+        <li onClick={() => mockFunctionality("Delete")}>Delete</li>
+      </ul>
+    </div>
+  );
+}
+
+export default TabMenu;

--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -20,8 +20,9 @@ ul li {
   border: 1px solid white;
   border-top: none;
   border-radius: 5px;
+  height: 40px;
   padding: 10px;
-  margin: 0 5px 5px 5px;
+  margin: 0 5px 10px 5px;
   background-color: rgba(255, 255, 255, 0.03);
   font-family: "Oxygen Mono", monospace;
 }


### PR DESCRIPTION
## Summary

This PR addresses Issue #6. This adds a menu to a GroupTab so group-related functionality can be initiated from the group's tab when selected. This ticket gets the rendering of the menu and basic show/hide behavior functioning. 

## Changes

- Changes the FontAwesome icon used for `<TabOptions />` to a chevron-like icon. This makes it clearer that there is something to drop down or fold up in relation to the tab.
- Adds a `<TabMenu />` component and styling that is rendered when the `<TabOptions />` icon is clicked and is hidden when the component loses focus.
  - Had an interesting conversation with CoPilot regarding this feature and learned about the `ref` attribute that is available within React which can be used in combination with `useRef` to manipulate that element. Here I'm using it to set the focus on the element once rendered, and to force the same element to blur when I click elsewhere on the page.