### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: []
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.3
+        with:
+          dry: True  # Doesn't overwrite files, fails if a change is needed
+          github_token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -10,7 +10,10 @@ function useApp() {
     updateConfig(newConfig);
   };
 
-  const updateConfig = (newConfigObj) => { localStorage.setItem("dialer-config", JSON.stringify(newConfigObj)); setConfig(newConfigObj);};
+  const updateConfig = (newConfigObj) => {
+    localStorage.setItem("dialer-config", JSON.stringify(newConfigObj));
+    setConfig(newConfigObj);
+  };
 
   const updateGroupIndex = (newIndex) => {
     if (newIndex !== config.groupIndex) {

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -10,10 +10,7 @@ function useApp() {
     updateConfig(newConfig);
   };
 
-  const updateConfig = (newConfigObj) => {
-    localStorage.setItem("dialer-config", JSON.stringify(newConfigObj));
-    setConfig(newConfigObj);
-  };
+  const updateConfig = (newConfigObj) => { localStorage.setItem("dialer-config", JSON.stringify(newConfigObj)); setConfig(newConfigObj);};
 
   const updateGroupIndex = (newIndex) => {
     if (newIndex !== config.groupIndex) {


### PR DESCRIPTION
## Summary

This PR addresses Issue #27 which requests a GitHub Action that will run a `prettier` check on code being integrated into the repo. 

The issue originally mentioned having the formatting check performed on any push to GitHub, but I believe having it run on pull requests instead will save some time and compute since we only really care when it's time to reconcile the branch against `main`.

The contents of `ci.yml` are a slightly modified template provided by the [Prettier Action](https://github.com/marketplace/actions/prettier-action#example-4-dry-run) in the GitHub Marketplace.

## Changes

- Created `ci` workflow to run the `prettier` dry-run (doesn't overwrite files and fails if a needed change is detected) on pull requests to any branch.