### PR TITLE
Refactor Views in App

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,8 +1,8 @@
-import "./App.css";
 import Dialer from "../Dialer/Dialer";
-import useApp from "./useApp";
-import GroupTabs from "../GroupTabs/GroupTabs";
 import { Settings } from "../Settings/Settings";
+
+import "./App.css";
+import useApp from "./useApp";
 
 function App() {
   const {
@@ -21,39 +21,35 @@ function App() {
     bodyEl.style.backgroundImage = `url('${config.background}')`;
   }
 
-  function mainContent() {
-    return ( config &&
-      <Dialer
-        dialGroup={config.dialGroups[config.groupIndex]}
-        dialsVisibility={dialsVisibility}
-        setDialsVisibility={setDialsVisibility} 
-        timeEnabled={config.timeEnabled}
-        timeFormat={config.timeFormat}
-      />
+  const renderDialer = () => {
+    return (
+      config && (
+        <Dialer
+          dialGroups={config.dialGroups}
+          dialsVisibility={dialsVisibility}
+          groupIndex={config.groupIndex}
+          setDialsVisibility={setDialsVisibility}
+          setShowSettings={setShowSettings}
+          timeEnabled={config.timeEnabled}
+          timeFormat={config.timeFormat}
+          updateGroupIndex={updateGroupIndex}
+        />
+      )
     );
-  }
+  };
 
   return (
     <div id="App">
       {config && config.background ? setBackgroundImg() : null}
-      {config && config.dialGroups ? (
-        <GroupTabs
-          groups={config.dialGroups}
-          groupIndex={config.groupIndex}
-          updateGroupIndex={updateGroupIndex}
-          showSettings={showSettings}
-          setShowSettings={setShowSettings}
-        />
-      ) : null}
       {showSettings ? (
         <Settings
           config={config}
-          configUrl={config.configUrl}
           getData={getData}
+          setShowSettings={setShowSettings}
           updateSetting={updateSetting}
         />
       ) : (
-        mainContent()
+        renderDialer()
       )}
     </div>
   );

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -1,9 +1,8 @@
 import "./App.css";
+import Dialer from "../Dialer/Dialer";
 import useApp from "./useApp";
 import GroupTabs from "../GroupTabs/GroupTabs";
 import { Settings } from "../Settings/Settings";
-import Time from "../Time/Time";
-import DialGroup from "../Dials/DialGroup";
 
 function App() {
   const {
@@ -23,19 +22,14 @@ function App() {
   }
 
   function mainContent() {
-    if (!config) return;
-
-    return (
-      <>
-        {config.timeEnabled ? <Time timeFormat={config.timeFormat} /> : null}
-        {config.dialGroups ? (
-          <DialGroup
-            {...config.dialGroups[config.groupIndex]}
-            dialVisibility={dialsVisibility}
-            setDialVisibility={setDialsVisibility}
-          />
-        ) : null}
-      </>
+    return ( config &&
+      <Dialer
+        dialGroup={config.dialGroups[config.groupIndex]}
+        dialsVisibility={dialsVisibility}
+        setDialsVisibility={setDialsVisibility} 
+        timeEnabled={config.timeEnabled}
+        timeFormat={config.timeFormat}
+      />
     );
   }
 

--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -1,0 +1,22 @@
+import Time from "../Time/Time";
+import DialGroup from "../Dials/DialGroup";
+
+
+export default function Dialer({ 
+  dialGroup, 
+  dialsVisibility,
+  setDialsVisibility,
+  timeEnabled, 
+  timeFormat, 
+}) {
+  return (<>
+    {timeEnabled && <Time timeFormat={timeFormat} />}
+
+      <DialGroup
+        {...dialGroup}
+        dialsVisibility={dialsVisibility}
+        setDialsVisibility={setDialsVisibility}
+      />
+
+  </>)
+}

--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -1,22 +1,35 @@
-import Time from "../Time/Time";
 import DialGroup from "../Dials/DialGroup";
+import GroupTabs from "../GroupTabs/GroupTabs";
+import Time from "../Time/Time";
 
-
-export default function Dialer({ 
-  dialGroup, 
+export default function Dialer({
+  dialGroups,
   dialsVisibility,
+  groupIndex,
   setDialsVisibility,
-  timeEnabled, 
-  timeFormat, 
+  setShowSettings,
+  timeEnabled,
+  timeFormat,
+  updateGroupIndex,
 }) {
-  return (<>
-    {timeEnabled && <Time timeFormat={timeFormat} />}
+  return (
+    dialGroups && (
+      <>
+        <GroupTabs
+          groups={dialGroups}
+          groupIndex={groupIndex}
+          setShowSettings={setShowSettings}
+          updateGroupIndex={updateGroupIndex}
+        />
 
-      <DialGroup
-        {...dialGroup}
-        dialsVisibility={dialsVisibility}
-        setDialsVisibility={setDialsVisibility}
-      />
+        {timeEnabled && <Time timeFormat={timeFormat} />}
 
-  </>)
+        <DialGroup
+          {...dialGroups[groupIndex]}
+          dialsVisibility={dialsVisibility}
+          setDialsVisibility={setDialsVisibility}
+        />
+      </>
+    )
+  );
 }

--- a/src/Dials/DialGroup.js
+++ b/src/Dials/DialGroup.js
@@ -2,11 +2,11 @@ import "./dialGroup.css";
 import Dial from "./Dial";
 import useDialGroup from "./useDialGroup";
 
-function DialGroup({ groupDials, dialVisibility, setDialVisibility }) {
-  const { handleImgLoad } = useDialGroup(groupDials, setDialVisibility);
+function DialGroup({ groupDials, dialsVisibility, setDialsVisibility }) {
+  const { handleImgLoad } = useDialGroup(groupDials, setDialsVisibility);
 
   return (
-    <div className={`DialGroup ${dialVisibility ? "fade-in" : "fade-out"}`}>
+    <div className={`DialGroup ${dialsVisibility ? "fade-in" : "fade-out"}`}>
       {groupDials.map((dialData, index) => {
         return <Dial {...dialData} key={index} onImgLoad={handleImgLoad} />;
       })}

--- a/src/Dials/useDialGroup.js
+++ b/src/Dials/useDialGroup.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-function useDialGroup(groupDials, setDialVisibility) {
+function useDialGroup(groupDials, setDialsVisibility) {
   const [loadedImgCount, setLoadedImgCount] = useState(0);
 
   useEffect(() => {
@@ -9,7 +9,7 @@ function useDialGroup(groupDials, setDialVisibility) {
 
   useEffect(() => {
     if (loadedImgCount === groupDials.length) {
-      setDialVisibility(true);
+      setDialsVisibility(true);
     }
   }, [loadedImgCount, groupDials.length]);
 

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -2,9 +2,10 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAnglesDown, faAnglesUp } from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 
+import { SettingsTab } from "../Settings/Settings";
+
 import "./groupTabs.css";
 import TabMenu from "./TabMenu/TabMenu";
-import { SettingsTab } from "../Settings/Settings";
 
 function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   const [showTabMenu, setShowTabMenu] = useState(false);
@@ -50,16 +51,10 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   );
 }
 
-function GroupTabs({
-  groups,
-  groupIndex,
-  updateGroupIndex,
-  showSettings,
-  setShowSettings,
-}) {
+function GroupTabs({ groups, groupIndex, setShowSettings, updateGroupIndex }) {
   return (
-    <div id="GroupTabs">
-      <ul className={showSettings ? "hide-tabs" : ""}>
+    <nav className="GroupTabs">
+      <ul>
         {groups.map((group, idx) => {
           return (
             <GroupTab
@@ -71,11 +66,8 @@ function GroupTabs({
           );
         })}
       </ul>
-      <SettingsTab
-        showSettings={showSettings}
-        setShowSettings={setShowSettings}
-      />
-    </div>
+      <SettingsTab setShowSettings={setShowSettings} />
+    </nav>
   );
 }
 

--- a/src/GroupTabs/TabMenu/TabMenu.css
+++ b/src/GroupTabs/TabMenu/TabMenu.css
@@ -1,4 +1,4 @@
-.tabMenu {
+.TabMenu {
   position: absolute;
   border: 1px solid #ccc;
   border-radius: 5px;
@@ -8,7 +8,7 @@
   left: 0;
 }
 
-.tabMenu ul {
+.TabMenu ul {
   list-style: none;
   display: flex;
   flex-direction: column;
@@ -16,7 +16,7 @@
   padding: 0;
 }
 
-.tabMenu li {
+.TabMenu ul li {
   top: 0;
   border: none;
   margin: 5px;
@@ -24,6 +24,6 @@
   cursor: pointer;
 }
 
-.tabMenu li:hover {
+.TabMenu li:hover {
   background-color: #f0f0f05b;
 }

--- a/src/GroupTabs/TabMenu/TabMenu.js
+++ b/src/GroupTabs/TabMenu/TabMenu.js
@@ -18,7 +18,7 @@ function TabMenu({ onClose }) {
   });
 
   return (
-    <div ref={menuRef} className="tabMenu" onBlur={onClose} tabIndex={0}>
+    <div ref={menuRef} className="TabMenu" onBlur={onClose} tabIndex={0}>
       <ul>
         <li onClick={() => mockFunctionality("Add")}>Add</li>
         <li onClick={() => mockFunctionality("Mopdify")}>Modify</li>

--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Oldenburg&family=Oxygen+Mono&display=swap");
 
-#GroupTabs {
+.GroupTabs {
   color: white;
   display: flex;
   justify-content: space-between;
@@ -9,12 +9,12 @@
   z-index: 100;
 }
 
-ul {
+.GroupTabs ul {
   display: flex;
   flex-direction: row;
 }
 
-ul li {
+.GroupTabs ul li {
   position: relative;
   top: -5px;
   border: 1px solid white;
@@ -34,8 +34,4 @@ ul li {
 .tabOptions {
   display: inline;
   margin: 0 5px 0 10px;
-}
-
-.hide-tabs {
-  visibility: hidden;
 }

--- a/src/NavClose/NavClose.css
+++ b/src/NavClose/NavClose.css
@@ -1,0 +1,21 @@
+.NavClose {
+  color: white;
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.NavClose ul li {
+  position: relative;
+  top: -5px;
+  border: 1px solid white;
+  border-top: none;
+  border-radius: 5px;
+  height: 40px;
+  padding: 10px;
+  margin: 0 5px 10px 5px;
+  background-color: rgba(255, 105, 105, 0.5);
+}

--- a/src/NavClose/NavClose.js
+++ b/src/NavClose/NavClose.js
@@ -1,0 +1,16 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRectangleXmark } from "@fortawesome/free-solid-svg-icons";
+
+import "./NavClose.css";
+
+export default function NavClose({ onClose }) {
+  return (
+    <nav className="NavClose">
+      <ul>
+        <li>
+          <FontAwesomeIcon onClick={onClose} icon={faRectangleXmark} />
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/Settings/Settings.css
+++ b/src/Settings/Settings.css
@@ -14,7 +14,7 @@ h2 {
   width: 33%;
 }
 
-#Settings {
+.Settings {
   font-family: monospace;
   color: white;
 }
@@ -22,8 +22,4 @@ h2 {
 .refresh-icon {
   color: white;
   margin-left: 5px;
-}
-
-.close-attention {
-  background-color: rgba(255, 105, 105, 0.5);
 }

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -1,32 +1,27 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faGear,
-  faRectangleXmark,
-  faRefresh,
-} from "@fortawesome/free-solid-svg-icons";
+import { faGear, faRefresh } from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
+
+import NavClose from "../NavClose/NavClose";
 
 import "./Settings.css";
 import { TimeSettings } from "./TimeSettings/TimeSettings";
 
-export function SettingsTab({ showSettings, setShowSettings }) {
+export function SettingsTab({ setShowSettings }) {
   function handleClick() {
-    setShowSettings(!showSettings);
+    setShowSettings(true);
   }
   return (
     <ul>
-      <li className={showSettings ? "close-attention" : ""}>
-        <FontAwesomeIcon
-          onClick={handleClick}
-          icon={showSettings ? faRectangleXmark : faGear}
-        />
+      <li>
+        <FontAwesomeIcon onClick={handleClick} icon={faGear} />
       </li>
     </ul>
   );
 }
 
-export function Settings({ config, configUrl, getData, updateSetting }) {
-  const [urlInputValue, setUrlInputValue] = useState(configUrl);
+export function Settings({ config, getData, setShowSettings, updateSetting }) {
+  const [urlInputValue, setUrlInputValue] = useState(config.configUrl);
 
   const handleConfigRefresh = () => {
     const newUrl = document.getElementById("config-url");
@@ -39,26 +34,29 @@ export function Settings({ config, configUrl, getData, updateSetting }) {
   };
 
   return (
-    <div id="Settings">
-      <h1>Settings</h1>
-      <h2>Config File URL</h2>
-      <input
-        type="text"
-        label="configURL"
-        id="config-url"
-        value={urlInputValue}
-        onChange={handleUrlChange}
-      />
-      <FontAwesomeIcon
-        onClick={handleConfigRefresh}
-        icon={faRefresh}
-        className="refresh-icon"
-      />
-      <TimeSettings
-        timeEnabled={config.timeEnabled}
-        timeFormat={config.timeFormat}
-        updateSetting={updateSetting}
-      />
-    </div>
+    <>
+      <NavClose onClose={() => setShowSettings(false)} />
+      <div className="Settings">
+        <h1>Settings</h1>
+        <h2>Config File URL</h2>
+        <input
+          type="text"
+          label="configURL"
+          id="config-url"
+          value={urlInputValue}
+          onChange={handleUrlChange}
+        />
+        <FontAwesomeIcon
+          onClick={handleConfigRefresh}
+          icon={faRefresh}
+          className="refresh-icon"
+        />
+        <TimeSettings
+          timeEnabled={config.timeEnabled}
+          timeFormat={config.timeFormat}
+          updateSetting={updateSetting}
+        />
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

This PR addresses Issue #31.

The conditional rendering occurring in the top-level `<App />` component was beginning to get messy. In order to tidy things up and make components more reusable and controllable, a "Dialer" view will hold all components considered part of the normal application view while in use. That way a separate "Settings" view can take over the App, and a future dial group settings view can be rendered in the Dialer rather than add a third view to the App level.

This is super-wordy but I'm basically reorganizing and bundling components to make it easier to swap between views without a Router.

## Changes

- Created a `<Dialer />` component to hold the `<GroupTabs />` and `<DialGroup />` components so they are easily rendered at the same time.
- Created a `<NavClose />` component that is basically a tab with a red X that indicates the current view can be closed. This component should be reused if I create any other closable views. This was previously tightly coupled with `SettingsTab` and seemed like something I would want to reuse in the future.
- Some capitalization changes for consistency in CSS class names and adding the missing plural "s" in `dialsVisibility` and `setDialsVisibility` in the few locations it differed.
- Updated the prop drilling as needed after the refactor in order to keep the UI interactivity intact. 