### PR TITLE
Group Details View

### DIFF
--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -1,4 +1,7 @@
+import { useState } from "react";
+
 import DialGroup from "../Dials/DialGroup";
+import GroupDetails from "../GroupDetails/GroupDetails";
 import GroupTabs from "../GroupTabs/GroupTabs";
 import Time from "../Time/Time";
 
@@ -12,23 +15,33 @@ export default function Dialer({
   timeFormat,
   updateGroupIndex,
 }) {
+  const [showDetails, setShowDetails] = useState(false);
+
   return (
     dialGroups && (
       <>
         <GroupTabs
           groups={dialGroups}
           groupIndex={groupIndex}
+          setShowDetails={setShowDetails}
           setShowSettings={setShowSettings}
           updateGroupIndex={updateGroupIndex}
         />
 
         {timeEnabled && <Time timeFormat={timeFormat} />}
 
-        <DialGroup
-          {...dialGroups[groupIndex]}
-          dialsVisibility={dialsVisibility}
-          setDialsVisibility={setDialsVisibility}
-        />
+        {showDetails ? (
+          <GroupDetails
+            {...dialGroups[groupIndex]}
+            setShowDetails={setShowDetails}
+          />
+        ) : (
+          <DialGroup
+            {...dialGroups[groupIndex]}
+            dialsVisibility={dialsVisibility}
+            setDialsVisibility={setDialsVisibility}
+          />
+        )}
       </>
     )
   );

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -1,0 +1,3 @@
+.GroupDetails {
+  color: white;
+}

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -25,6 +25,7 @@ export default function GroupDetails({
           <DialDetail {...dial} />
         ))}
       </ul>
+      <button>Add Dial</button>
       <button onClick={() => setShowDetails(false)}>Cancel</button>
       <button>Apply</button>
     </div>

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+import "./GroupDetails.css";
+
+function DialDetail({ name, image, url }) {
+  return (
+    <li>
+      {name} - {url} - {image}
+    </li>
+  );
+}
+
+export default function GroupDetails({
+  groupDials,
+  groupName,
+  setShowDetails,
+}) {
+  const [dials, setDials] = useState([...groupDials]);
+
+  return (
+    <div className="GroupDetails">
+      <h1>{groupName}</h1>
+      <ul>
+        {dials.map((dial) => (
+          <DialDetail {...dial} />
+        ))}
+      </ul>
+      <button onClick={() => setShowDetails(false)}>Cancel</button>
+      <button>Apply</button>
+    </div>
+  );
+}

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -7,7 +7,13 @@ import { SettingsTab } from "../Settings/Settings";
 import "./groupTabs.css";
 import TabMenu from "./TabMenu/TabMenu";
 
-function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
+function GroupTab({
+  group,
+  idx,
+  isSelected,
+  setShowDetails,
+  updateGroupIndex,
+}) {
   const [showTabMenu, setShowTabMenu] = useState(false);
 
   function TabOptions({ onClick }) {
@@ -24,6 +30,7 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
   function handleClick({ target }) {
     const liElement = target.closest("li[data-index]");
     if (liElement) {
+      setShowDetails(false);
       updateGroupIndex(liElement.dataset.index);
     }
   }
@@ -46,12 +53,20 @@ function GroupTab({ group, idx, isSelected, updateGroupIndex }) {
     >
       {group.groupName}
       {isSelected && <TabOptions onClick={openMenu} />}
-      {showTabMenu && <TabMenu onClose={closeMenu} />}
+      {showTabMenu && (
+        <TabMenu onClose={closeMenu} setShowDetails={setShowDetails} />
+      )}
     </li>
   );
 }
 
-function GroupTabs({ groups, groupIndex, setShowSettings, updateGroupIndex }) {
+function GroupTabs({
+  groups,
+  groupIndex,
+  setShowDetails,
+  setShowSettings,
+  updateGroupIndex,
+}) {
   return (
     <nav className="GroupTabs">
       <ul>
@@ -61,6 +76,7 @@ function GroupTabs({ groups, groupIndex, setShowSettings, updateGroupIndex }) {
               group={group}
               idx={idx}
               isSelected={idx === parseInt(groupIndex)}
+              setShowDetails={setShowDetails}
               updateGroupIndex={updateGroupIndex}
             />
           );

--- a/src/GroupTabs/TabMenu/TabMenu.js
+++ b/src/GroupTabs/TabMenu/TabMenu.js
@@ -2,12 +2,19 @@ import { useEffect, useRef } from "react";
 
 import "./TabMenu.css";
 
-function TabMenu({ onClose }) {
+function TabMenu({ onClose, setShowDetails }) {
   const menuRef = useRef(null);
 
   // TODO: Remove this
-  const mockFunctionality = (name) => {
+  const mockFunctionality = (event, name) => {
+    event.stopPropagation();
     console.log(`${name} was selected`);
+    if (menuRef.current) menuRef.current.blur();
+  };
+
+  const openDetails = (event) => {
+    event.stopPropagation();
+    setShowDetails(true);
     if (menuRef.current) menuRef.current.blur();
   };
 
@@ -20,9 +27,9 @@ function TabMenu({ onClose }) {
   return (
     <div ref={menuRef} className="TabMenu" onBlur={onClose} tabIndex={0}>
       <ul>
-        <li onClick={() => mockFunctionality("Add")}>Add</li>
-        <li onClick={() => mockFunctionality("Mopdify")}>Modify</li>
-        <li onClick={() => mockFunctionality("Delete")}>Delete</li>
+        <li onClick={(e) => mockFunctionality(e, "Add Dial")}>Add Dial</li>
+        <li onClick={openDetails}>Edit Group</li>
+        <li onClick={(e) => mockFunctionality(e, "New Group")}>New Group</li>
       </ul>
     </div>
   );

--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -28,7 +28,7 @@
 }
 
 .selectedGroup {
-  background-color: rgba(255, 255, 255, 0.18);
+  background-color: rgba(255, 255, 255, 0.18) !important;
 }
 
 .tabOptions {


### PR DESCRIPTION
## Summary

This PR addresses Issue #21 which is the beginning of the Group Details view, basically the settings for a specific group of dials. This scaffolded out the view and its interaction with the Tab Menu. Real functionality will be added into this view piecemeal in other Issues.

## Changes

- Created a `<GroupDetails />` component where the details of a group's dials will be displayed for modification.
- Needed to add `event.stopPropagation()` to the Tab Menu because it was triggering listeners in the parent Group Tab when the "Edit" or any other option was selected.
- Added basic readout of a group's dials and buttons that will trigger future functionality.
- Ensured behavior around showing/hiding the view when clicking on another tab while the Group Details view is open, closes the view and opens the selected tab's dials.