### PR TITLE
Reorder Dials

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -14,6 +14,7 @@ function App() {
     showSettings,
     setShowSettings,
     updateSetting,
+    updateGroupDials,
   } = useApp();
 
   function setBackgroundImg() {
@@ -33,6 +34,7 @@ function App() {
           timeEnabled={config.timeEnabled}
           timeFormat={config.timeFormat}
           updateGroupIndex={updateGroupIndex}
+          updateGroupDials={updateGroupDials}
         />
       )
     );

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -15,6 +15,18 @@ function useApp() {
     setConfig(newConfigObj);
   };
 
+  const updateGroupDials = (groupName, newDials) => {
+    const newConfig = {
+      ...config,
+      dialGroups: config.dialGroups.map((group) =>
+        group.groupName === groupName
+          ? { ...group, groupDials: newDials }
+          : group,
+      ),
+    };
+    updateConfig(newConfig);
+  };
+
   const updateGroupIndex = (newIndex) => {
     if (newIndex !== config.groupIndex) {
       const newConfig = { ...config, groupIndex: newIndex };
@@ -54,6 +66,7 @@ function useApp() {
     showSettings,
     setShowSettings,
     updateSetting,
+    updateGroupDials,
   };
 }
 

--- a/src/ArrowSelector/ArrowSelector.css
+++ b/src/ArrowSelector/ArrowSelector.css
@@ -1,3 +1,9 @@
+.ArrowSelector {
+  display: flex;
+  flex-direction: column;
+  padding: 5px;
+}
+
 .dimmed {
   color: #666;
 }

--- a/src/ArrowSelector/ArrowSelector.css
+++ b/src/ArrowSelector/ArrowSelector.css
@@ -1,0 +1,3 @@
+.dimmed {
+  color: #666;
+}

--- a/src/ArrowSelector/ArrowSelector.js
+++ b/src/ArrowSelector/ArrowSelector.js
@@ -1,0 +1,21 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
+
+import "./ArrowSelector.css";
+
+export function ArrowSelector({ downAble, onDown, onUp, upAble }) {
+  return (
+    <div className="ArrowSelector">
+      <FontAwesomeIcon
+        className={upAble ? "" : "dimmed"}
+        icon={faCaretUp}
+        onClick={onUp}
+      />
+      <FontAwesomeIcon
+        className={downAble ? "" : "dimmed"}
+        icon={faCaretDown}
+        onClick={onDown}
+      />
+    </div>
+  );
+}

--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -14,6 +14,7 @@ export default function Dialer({
   timeEnabled,
   timeFormat,
   updateGroupIndex,
+  updateGroupDials,
 }) {
   const [showDetails, setShowDetails] = useState(false);
 
@@ -34,6 +35,7 @@ export default function Dialer({
           <GroupDetails
             {...dialGroups[groupIndex]}
             setShowDetails={setShowDetails}
+            updateGroupDials={updateGroupDials}
           />
         ) : (
           <DialGroup

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -1,3 +1,17 @@
 .GroupDetails {
   color: white;
 }
+
+.DialDetails {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  min-height: 60px;
+  border: 1px solid white;
+  border-radius: 5px;
+}
+
+.DialDetails img {
+  height: 50px;
+  width: 50px;
+}

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -14,4 +14,5 @@
 .DialDetails img {
   height: 50px;
   width: 50px;
+  margin: 0 5px;
 }

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -13,7 +13,11 @@ function DialDetails({ index, first, last, name, image, url, shiftDial }) {
         upAble={!first}
       />
       <img src={image} alt={name} />
-      {name} - {url} - {image}
+      <div>
+        <p>{name}</p>
+        <p>{url}</p>
+        <p>{image}</p>
+      </div>
     </li>
   );
 }

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,10 +1,18 @@
 import { useState } from "react";
 
 import "./GroupDetails.css";
+import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
 
-function DialDetail({ name, image, url }) {
+function DialDetails({ index, first, last, name, image, url, shiftDial }) {
   return (
-    <li>
+    <li className="DialDetails">
+      <ArrowSelector
+        downAble={!last}
+        onDown={() => shiftDial(index, 1)}
+        onUp={() => shiftDial(index, -1)}
+        upAble={!first}
+      />
+      <img src={image} alt={name} />
       {name} - {url} - {image}
     </li>
   );
@@ -14,20 +22,39 @@ export default function GroupDetails({
   groupDials,
   groupName,
   setShowDetails,
+  updateGroupDials,
 }) {
   const [dials, setDials] = useState([...groupDials]);
+
+  const shiftDial = (index, offset) => {
+    const newDials = [...dials];
+    const dial = newDials.splice(index, 1)[0];
+    newDials.splice(index + offset, 0, dial);
+    setDials(newDials);
+  };
+
+  const applyChanges = (groupName, dials) => {
+    updateGroupDials(groupName, dials);
+    setShowDetails(false);
+  };
 
   return (
     <div className="GroupDetails">
       <h1>{groupName}</h1>
       <ul>
-        {dials.map((dial) => (
-          <DialDetail {...dial} />
+        {dials.map((dial, index) => (
+          <DialDetails
+            {...dial}
+            index={index}
+            first={index === 0}
+            last={index === dials.length - 1}
+            shiftDial={shiftDial}
+          />
         ))}
       </ul>
       <button>Add Dial</button>
       <button onClick={() => setShowDetails(false)}>Cancel</button>
-      <button>Apply</button>
+      <button onClick={() => applyChanges(groupName, dials)}>Apply</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR addresses Issue #31 which allows a user to reorder the dials within a group when editing the group itself.

## Changes

- Created an `<ArrowSelector />` component that conditionally renders the up and down arrows and accepts callback functions for each arrow.
- Updated `GroupDetail` with a `shiftDial` function to move the selected dial within the group.
- Updated `useApp` to include an `updateGroupDials` function to update the config in state and `localStorage` when the dials are reordered.
- Hooked up the "Apply" button so changes are only saved when "applied".
- Added some basic placeholder styling.