### PR TITLE
Apply Button

### DIFF
--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -17,6 +17,8 @@ export default function Dialer({
   updateGroupDials,
 }) {
   const [showDetails, setShowDetails] = useState(false);
+  const [isPendingChanges, setIsPendingChanges] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(null);
 
   return (
     dialGroups && (
@@ -24,6 +26,8 @@ export default function Dialer({
         <GroupTabs
           groups={dialGroups}
           groupIndex={groupIndex}
+          isPendingChanges={isPendingChanges}
+          setShowConfirm={setShowConfirm}
           setShowDetails={setShowDetails}
           setShowSettings={setShowSettings}
           updateGroupIndex={updateGroupIndex}
@@ -34,8 +38,13 @@ export default function Dialer({
         {showDetails ? (
           <GroupDetails
             {...dialGroups[groupIndex]}
+            showConfirm={showConfirm}
+            setShowConfirm={setShowConfirm}
+            isPendingChanges={isPendingChanges}
+            setIsPendingChanges={setIsPendingChanges}
             setShowDetails={setShowDetails}
             updateGroupDials={updateGroupDials}
+            updateGroupIndex={updateGroupIndex}
           />
         ) : (
           <DialGroup

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -25,3 +25,13 @@
   width: 50px;
   margin: 0 5px;
 }
+
+.hide {
+  display: none !important;
+}
+
+.confirm {
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -1,5 +1,13 @@
 .GroupDetails {
   color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.GroupDetails ul {
+  width: 50%;
+  min-width: 400px;
 }
 
 .DialDetails {
@@ -9,6 +17,7 @@
   min-height: 60px;
   border: 1px solid white;
   border-radius: 5px;
+  margin-bottom: 5px;
 }
 
 .DialDetails img {

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import "./GroupDetails.css";
+import { useGroupDetails } from "./useGroupDetails";
 import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
 
 function DialDetails({ index, first, last, name, image, url, shiftDial }) {
@@ -27,19 +28,12 @@ export default function GroupDetails({
   setShowDetails,
   updateGroupDials,
 }) {
-  const [dials, setDials] = useState([...groupDials]);
-
-  const shiftDial = (index, offset) => {
-    const newDials = [...dials];
-    const dial = newDials.splice(index, 1)[0];
-    newDials.splice(index + offset, 0, dial);
-    setDials(newDials);
-  };
-
-  const applyChanges = (groupName, dials) => {
-    updateGroupDials(groupName, dials);
-    setShowDetails(false);
-  };
+  const { dials, isPendingChanges, shiftDial, applyChanges } =
+    useGroupDetails({
+      groupDials,
+      setShowDetails,
+      updateGroupDials,
+    });
 
   return (
     <div className="GroupDetails">
@@ -57,7 +51,12 @@ export default function GroupDetails({
       </ul>
       <button>Add Dial</button>
       <button onClick={() => setShowDetails(false)}>Cancel</button>
-      <button onClick={() => applyChanges(groupName, dials)}>Apply</button>
+      <button
+        onClick={() => applyChanges(groupName, dials)}
+        disabled={!isPendingChanges}
+      >
+        Apply
+      </button>
     </div>
   );
 }

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -16,7 +16,6 @@ function DialDetails({ index, first, last, name, image, url, shiftDial }) {
       <div>
         <p>{name}</p>
         <p>{url}</p>
-        <p>{image}</p>
       </div>
     </li>
   );

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import "./GroupDetails.css";
 import { useGroupDetails } from "./useGroupDetails";
 import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
@@ -25,19 +23,34 @@ function DialDetails({ index, first, last, name, image, url, shiftDial }) {
 export default function GroupDetails({
   groupDials,
   groupName,
+  isPendingChanges,
+  setIsPendingChanges,
   setShowDetails,
+  showConfirm,
+  setShowConfirm,
   updateGroupDials,
+  updateGroupIndex,
 }) {
-  const { dials, isPendingChanges, shiftDial, applyChanges } =
+  const { applyChanges, dials, forceGroupNavigation, shiftDial } =
     useGroupDetails({
       groupDials,
+      setIsPendingChanges,
+      setShowConfirm,
       setShowDetails,
       updateGroupDials,
+      updateGroupIndex,
     });
 
   return (
     <div className="GroupDetails">
       <h1>{groupName}</h1>
+      <div className={`confirm ${showConfirm === null ? "hide" : ""}`}>
+        <p>Unsaved changes. Return to apply them or continue without saving.</p>
+        <button onClick={() => setShowConfirm(null)}>Return</button>
+        <button onClick={() => forceGroupNavigation(showConfirm.newIndex)}>
+          Continue
+        </button>
+      </div>
       <ul>
         {dials.map((dial, index) => (
           <DialDetails

--- a/src/GroupDetails/useGroupDetails.js
+++ b/src/GroupDetails/useGroupDetails.js
@@ -2,17 +2,20 @@ import { useEffect, useState } from "react";
 
 export function useGroupDetails({
   groupDials,
+  setIsPendingChanges,
+  setShowConfirm,
   setShowDetails,
   updateGroupDials,
+  updateGroupIndex,
 }) {
   const [dials, setDials] = useState([...groupDials]);
-  const [isPendingChanges, setIsPendingChanges] = useState(false);
 
-  const arraysEqual = (a, b) => a.length === b.length && a.every((val, index) => val === b[index]);
+  const arraysEqual = (a, b) =>
+    a.length === b.length && a.every((val, index) => val === b[index]);
 
   useEffect(() => {
     setIsPendingChanges(arraysEqual(groupDials, dials) ? false : true);
-  }, [dials, groupDials])
+  }, [dials, groupDials]);
 
   const shiftDial = (index, offset) => {
     const newDials = [...dials];
@@ -26,10 +29,17 @@ export function useGroupDetails({
     setShowDetails(false);
   };
 
+  function forceGroupNavigation(newIndex) {
+    setShowConfirm(null);
+    setShowDetails(false);
+    setIsPendingChanges(false);
+    updateGroupIndex(newIndex);
+  }
+
   return {
-    dials,
-    isPendingChanges,
-    shiftDial,
     applyChanges,
+    dials,
+    forceGroupNavigation,
+    shiftDial,
   };
 }

--- a/src/GroupDetails/useGroupDetails.js
+++ b/src/GroupDetails/useGroupDetails.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+export function useGroupDetails({
+  groupDials,
+  setShowDetails,
+  updateGroupDials,
+}) {
+  const [dials, setDials] = useState([...groupDials]);
+  const [isPendingChanges, setIsPendingChanges] = useState(false);
+
+  const arraysEqual = (a, b) => a.length === b.length && a.every((val, index) => val === b[index]);
+
+  useEffect(() => {
+    setIsPendingChanges(arraysEqual(groupDials, dials) ? false : true);
+  }, [dials, groupDials])
+
+  const shiftDial = (index, offset) => {
+    const newDials = [...dials];
+    const dial = newDials.splice(index, 1)[0];
+    newDials.splice(index + offset, 0, dial);
+    setDials(newDials);
+  };
+
+  const applyChanges = (groupName, dials) => {
+    updateGroupDials(groupName, dials);
+    setShowDetails(false);
+  };
+
+  return {
+    dials,
+    isPendingChanges,
+    shiftDial,
+    applyChanges,
+  };
+}

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -10,7 +10,9 @@ import TabMenu from "./TabMenu/TabMenu";
 function GroupTab({
   group,
   idx,
+  isPendingChanges,
   isSelected,
+  setShowConfirm,
   setShowDetails,
   updateGroupIndex,
 }) {
@@ -29,7 +31,9 @@ function GroupTab({
 
   function handleClick({ target }) {
     const liElement = target.closest("li[data-index]");
-    if (liElement) {
+    if (liElement && isPendingChanges) {
+      setShowConfirm({ newIndex: liElement.dataset.index });
+    } else if (liElement) {
       setShowDetails(false);
       updateGroupIndex(liElement.dataset.index);
     }
@@ -63,6 +67,8 @@ function GroupTab({
 function GroupTabs({
   groups,
   groupIndex,
+  isPendingChanges,
+  setShowConfirm,
   setShowDetails,
   setShowSettings,
   updateGroupIndex,
@@ -75,7 +81,9 @@ function GroupTabs({
             <GroupTab
               group={group}
               idx={idx}
+              isPendingChanges={isPendingChanges}
               isSelected={idx === parseInt(groupIndex)}
+              setShowConfirm={setShowConfirm}
               setShowDetails={setShowDetails}
               updateGroupIndex={updateGroupIndex}
             />


### PR DESCRIPTION
## Summary

This PR addresses issue #33 which requests improvements to the user experience around the "apply" button and unsaved changes.

## Changes

- Created `useGroupDetails.js` custom hook since there was a lot of state and behavior piling up in the `GroupDetails` component.
- Created `isPendingChanges` and `showConfirm` state values in `Dialer` in order to allow the `GroupDetails` and `GroupTabs` to know when we're trying to navigate away from the current view while there are pending changes. 
  - *It was a little more prop drilling that I hoped for but I think the UX is worth it. This can also be refactored later.*
- Added some basic styling for the `GroupDetails` view.
- Added a basic `div` for the confirmation dialog as a placeholder with buttons that allow a user to either return to the `GroupDetails` view or continue with navigating away while discarding changes. 
  - *This div will likely need to be it's own component to add an overlay over the entire app and such. The current implementation is not the prettiest but it is functional, for now.*
- Added a `useEffect` to `GroupDetails` that checks if its array of temporary dials matches the unmodified dials in state, this allows the app to know when there are unsaved changes.