### PR TITLE
Confirm Component

### DIFF
--- a/src/Confirm/Confirm.css
+++ b/src/Confirm/Confirm.css
@@ -1,0 +1,5 @@
+.Confirm {
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+}

--- a/src/Confirm/Confirm.css
+++ b/src/Confirm/Confirm.css
@@ -1,5 +1,33 @@
 .Confirm {
-    z-index: 100;
-    display: flex;
-    flex-direction: column;
+  position: fixed;
+  top: 0;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+}
+
+.popup {
+  background-color: #faf0e6;
+  color: black;
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  margin: auto;
+  padding: 20px;
+  border-radius: 5px;
+  text-align: center;
+}
+
+.popup button {
+  margin-top: 10px;
+  padding: 5px;
+  border: none;
+  border-radius: 5px;
+  background-color: #f4f4f4;
+  color: black;
+  cursor: pointer;
+  align-self: center;
 }

--- a/src/Confirm/Confirm.js
+++ b/src/Confirm/Confirm.js
@@ -1,0 +1,11 @@
+export function Confirm({ showConfirm, setShowConfirm, forceGroupNavigation }) {
+  return (
+    <div className={`confirm ${showConfirm === null ? "hide" : ""}`}>
+      <p>Unsaved changes. Return to apply them or continue without saving.</p>
+      <button onClick={() => setShowConfirm(null)}>Return</button>
+      <button onClick={() => forceGroupNavigation(showConfirm.newIndex)}>
+        Continue
+      </button>
+    </div>
+  );
+}

--- a/src/Confirm/Confirm.js
+++ b/src/Confirm/Confirm.js
@@ -1,11 +1,21 @@
-export function Confirm({ showConfirm, setShowConfirm, forceGroupNavigation }) {
+import "./Confirm.css";
+
+export function Confirm({ message, options }) {
   return (
-    <div className={`confirm ${showConfirm === null ? "hide" : ""}`}>
-      <p>Unsaved changes. Return to apply them or continue without saving.</p>
-      <button onClick={() => setShowConfirm(null)}>Return</button>
-      <button onClick={() => forceGroupNavigation(showConfirm.newIndex)}>
-        Continue
-      </button>
+    <div className={`Confirm`}>
+      <div className="popup">
+        <p>{message}</p>
+        {options.map((option) => {
+          const buttonStyle = option.color
+            ? { backgroundColor: option.color }
+            : {};
+          return (
+            <button style={buttonStyle} onClick={option.action}>
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -43,6 +43,7 @@ export default function Dialer({
             isPendingChanges={isPendingChanges}
             setIsPendingChanges={setIsPendingChanges}
             setShowDetails={setShowDetails}
+            setShowSettings={setShowSettings}
             updateGroupDials={updateGroupDials}
             updateGroupIndex={updateGroupIndex}
           />

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -29,9 +29,3 @@
 .hide {
   display: none !important;
 }
-
-.confirm {
-  z-index: 100;
-  display: flex;
-  flex-direction: column;
-}

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -29,16 +29,18 @@ export default function GroupDetails({
   setShowDetails,
   showConfirm,
   setShowConfirm,
+  setShowSettings,
   updateGroupDials,
   updateGroupIndex,
 }) {
-  const { applyChanges, confirmOptions, dials, message, shiftDial } =
+  const { applyChanges, confirmOptions, dials, message, onCancel, shiftDial } =
     useGroupDetails({
       groupDials,
       setIsPendingChanges,
       showConfirm,
       setShowConfirm,
       setShowDetails,
+      setShowSettings,
       updateGroupDials,
       updateGroupIndex,
     });
@@ -59,7 +61,7 @@ export default function GroupDetails({
         ))}
       </ul>
       <button>Add Dial</button>
-      <button onClick={() => setShowDetails(false)}>Cancel</button>
+      <button onClick={onCancel}>Cancel</button>
       <button
         onClick={() => applyChanges(groupName, dials)}
         disabled={!isPendingChanges}

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,6 +1,7 @@
 import "./GroupDetails.css";
 import { useGroupDetails } from "./useGroupDetails";
 import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
+import { Confirm } from "../Confirm/Confirm";
 
 function DialDetails({ index, first, last, name, image, url, shiftDial }) {
   return (
@@ -44,13 +45,7 @@ export default function GroupDetails({
   return (
     <div className="GroupDetails">
       <h1>{groupName}</h1>
-      <div className={`confirm ${showConfirm === null ? "hide" : ""}`}>
-        <p>Unsaved changes. Return to apply them or continue without saving.</p>
-        <button onClick={() => setShowConfirm(null)}>Return</button>
-        <button onClick={() => forceGroupNavigation(showConfirm.newIndex)}>
-          Continue
-        </button>
-      </div>
+      <Confirm showConfirm={showConfirm} setShowConfirm={setShowConfirm} forceGroupNavigation={forceGroupNavigation} />
       <ul>
         {dials.map((dial, index) => (
           <DialDetails

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -32,10 +32,11 @@ export default function GroupDetails({
   updateGroupDials,
   updateGroupIndex,
 }) {
-  const { applyChanges, dials, forceGroupNavigation, shiftDial } =
+  const { applyChanges, confirmOptions, dials, message, shiftDial } =
     useGroupDetails({
       groupDials,
       setIsPendingChanges,
+      showConfirm,
       setShowConfirm,
       setShowDetails,
       updateGroupDials,
@@ -45,7 +46,7 @@ export default function GroupDetails({
   return (
     <div className="GroupDetails">
       <h1>{groupName}</h1>
-      <Confirm showConfirm={showConfirm} setShowConfirm={setShowConfirm} forceGroupNavigation={forceGroupNavigation} />
+      {showConfirm && <Confirm message={message} options={confirmOptions} />}
       <ul>
         {dials.map((dial, index) => (
           <DialDetails

--- a/src/GroupDetails/useGroupDetails.js
+++ b/src/GroupDetails/useGroupDetails.js
@@ -6,6 +6,7 @@ export function useGroupDetails({
   showConfirm,
   setShowConfirm,
   setShowDetails,
+  setShowSettings,
   updateGroupDials,
   updateGroupIndex,
 }) {
@@ -34,7 +35,11 @@ export function useGroupDetails({
     setShowConfirm(null);
     setShowDetails(false);
     setIsPendingChanges(false);
-    updateGroupIndex(newIndex);
+    if (newIndex === "settings") {
+      setShowSettings(true);
+    } else {
+      updateGroupIndex(newIndex);
+    }
   }
 
   const confirmOptions = [
@@ -52,11 +57,17 @@ export function useGroupDetails({
 
   const message = "You have unsaved changes.";
 
+  const onCancel = () => {
+    setIsPendingChanges(false);
+    setShowDetails(false);
+  };
+
   return {
     applyChanges,
     confirmOptions,
     dials,
     message,
+    onCancel,
     shiftDial,
   };
 }

--- a/src/GroupDetails/useGroupDetails.js
+++ b/src/GroupDetails/useGroupDetails.js
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 export function useGroupDetails({
   groupDials,
   setIsPendingChanges,
+  showConfirm,
   setShowConfirm,
   setShowDetails,
   updateGroupDials,
@@ -36,10 +37,26 @@ export function useGroupDetails({
     updateGroupIndex(newIndex);
   }
 
+  const confirmOptions = [
+    {
+      label: "Return to Apply Changes",
+      action: () => setShowConfirm(null),
+      color: "#4CAF50",
+    },
+    {
+      label: "Continue Without Saving",
+      action: () => forceGroupNavigation(showConfirm.newIndex),
+      color: "#f44336",
+    },
+  ];
+
+  const message = "You have unsaved changes.";
+
   return {
     applyChanges,
+    confirmOptions,
     dials,
-    forceGroupNavigation,
+    message,
     shiftDial,
   };
 }

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -90,7 +90,11 @@ function GroupTabs({
           );
         })}
       </ul>
-      <SettingsTab setShowSettings={setShowSettings} />
+      <SettingsTab
+        isPendingChanges={isPendingChanges}
+        setShowConfirm={setShowConfirm}
+        setShowSettings={setShowSettings}
+      />
     </nav>
   );
 }

--- a/src/GroupTabs/TabMenu/TabMenu.css
+++ b/src/GroupTabs/TabMenu/TabMenu.css
@@ -17,11 +17,13 @@
 }
 
 .TabMenu ul li {
+  height: auto;
   top: 0;
   border: none;
   margin: 5px;
   padding: 10px;
   cursor: pointer;
+  text-align: center;
 }
 
 .TabMenu li:hover {

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -7,9 +7,17 @@ import NavClose from "../NavClose/NavClose";
 import "./Settings.css";
 import { TimeSettings } from "./TimeSettings/TimeSettings";
 
-export function SettingsTab({ setShowSettings }) {
+export function SettingsTab({
+  isPendingChanges,
+  setShowConfirm,
+  setShowSettings,
+}) {
   function handleClick() {
-    setShowSettings(true);
+    if (isPendingChanges) {
+      setShowConfirm({ newIndex: "settings" });
+    } else {
+      setShowSettings(true);
+    }
   }
   return (
     <ul>


### PR DESCRIPTION
## Summary

This PR addresses Issue #38 which requests a refactor of the HTML and interaction surrounding the confirmation popup that appears when trying to navigate away from unsaved changes in `GroupDetails`. 

## Changes

- Created a `<Confirm />` component that takes in a `message` and `options`. The `options` are an array of objects that contain an `action`, `label`, and optional `color` properties. This allows the `Confirm` component to render multiple options.
- Updated `SettingsTab` with props in order to allow it to be aware of when pending changes should cause a confirmation to pop up.
  - *This is another area where I should probably start trying to get more nuanced state management techniques involved. The prop drilling is starting to feel cumbersome.*
-  Added some additional styling.