### PR TITLE
Delete Dial from Group

### DIFF
--- a/src/Confirm/Confirm.css
+++ b/src/Confirm/Confirm.css
@@ -1,6 +1,7 @@
 .Confirm {
   position: fixed;
   top: 0;
+  left: 0;
   height: 100vh;
   width: 100vw;
   background-color: rgba(0, 0, 0, 0.5);

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -26,6 +26,8 @@
   margin: 0 5px;
 }
 
-.hide {
-  display: none !important;
+.DialDetails .faTrash {
+  margin-left: auto;
+  margin-right: 5px;
+  cursor: pointer;
 }

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,3 +1,6 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrash } from "@fortawesome/free-solid-svg-icons";
+
 import "./GroupDetails.css";
 import { useGroupDetails } from "./useGroupDetails";
 import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
@@ -17,6 +20,11 @@ function DialDetails({ index, first, last, name, image, url, shiftDial }) {
         <p>{name}</p>
         <p>{url}</p>
       </div>
+      <FontAwesomeIcon
+        className="faTrash"
+        icon={faTrash}
+        onClick={() => shiftDial(index, null)}
+      />
     </li>
   );
 }

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,10 +1,43 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { useState } from "react";
 
 import "./GroupDetails.css";
 import { useGroupDetails } from "./useGroupDetails";
 import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
 import { Confirm } from "../Confirm/Confirm";
+
+function DeleteDial({ index, shiftDial }) {
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const deleteDial = () => {
+    setConfirmDelete(false);
+    shiftDial(index, null);
+  };
+
+  return (
+    <>
+      <FontAwesomeIcon
+        className="faTrash"
+        icon={faTrash}
+        onClick={() => setConfirmDelete(true)}
+      />
+      {confirmDelete && (
+        <Confirm
+          message="Delete this dial?"
+          options={[
+            {
+              label: "Cancel",
+              action: () => setConfirmDelete(false),
+              color: "#4CAF50",
+            },
+            { label: "Delete", action: deleteDial, color: "#f44336" },
+          ]}
+        />
+      )}
+    </>
+  );
+}
 
 function DialDetails({ index, first, last, name, image, url, shiftDial }) {
   return (
@@ -20,11 +53,7 @@ function DialDetails({ index, first, last, name, image, url, shiftDial }) {
         <p>{name}</p>
         <p>{url}</p>
       </div>
-      <FontAwesomeIcon
-        className="faTrash"
-        icon={faTrash}
-        onClick={() => shiftDial(index, null)}
-      />
+      <DeleteDial index={index} shiftDial={shiftDial} />
     </li>
   );
 }

--- a/src/GroupDetails/useGroupDetails.js
+++ b/src/GroupDetails/useGroupDetails.js
@@ -20,9 +20,12 @@ export function useGroupDetails({
   }, [dials, groupDials]);
 
   const shiftDial = (index, offset) => {
+    // If offset is null, the dial is deleted rather than shifted
     const newDials = [...dials];
     const dial = newDials.splice(index, 1)[0];
-    newDials.splice(index + offset, 0, dial);
+    if (offset !== null) {
+      newDials.splice(index + offset, 0, dial);
+    }
     setDials(newDials);
   };
 


### PR DESCRIPTION
## Summary

This PR addresses Issue #23 which requests the ability to delete a Dial from a Dial Group. 

## Changes

- Creates a `DeleteDial` component that is added to each `DialDetails` list item.
- Updated `shiftDial` function to allow it to delete a dial if `null` is provided as the new target `index`.
- Added simple styling to position the trash icon and ensure that every `Confirm` stretches to darken the entire screen.