### PR TITLE
Reorder Groups

### DIFF
--- a/src/Dials/Dial.js
+++ b/src/Dials/Dial.js
@@ -1,7 +1,7 @@
-function Dial({ icon, onImgLoad, name, link }, key) {
+function Dial({ icon, name, link }, key) {
   return (
     <a href={link} key={key}>
-      <img src={icon} alt={name} onLoad={onImgLoad} />
+      <img src={icon} alt={name} />
     </a>
   );
 }

--- a/src/Dials/DialGroup.js
+++ b/src/Dials/DialGroup.js
@@ -3,12 +3,12 @@ import Dial from "./Dial";
 import useDialGroup from "./useDialGroup";
 
 function DialGroup() {
-  const { dials, handleImgLoad, showDials } = useDialGroup();
+  const { dials, showDials } = useDialGroup();
 
   return (
     <div className={`DialGroup ${showDials ? "fade-in" : "fade-out"}`}>
       {dials.map((dialData, index) => {
-        return <Dial {...dialData} key={index} onImgLoad={handleImgLoad} />;
+        return <Dial {...dialData} key={index} />;
       })}
     </div>
   );

--- a/src/GroupDetails/useGroupDetails.js
+++ b/src/GroupDetails/useGroupDetails.js
@@ -56,7 +56,7 @@ export function useGroupDetails({
     if (newIndex === "settings") {
       setShowSettings(true);
     } else {
-      updateSetting("currentGroupIndex", newIndex);
+      updateSetting("currentGroupIndex", parseInt(newIndex));
     }
   }
 

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -61,7 +61,12 @@ function GroupTab({ idx, name, setShowConfirm, setShowDetails }) {
       {name}
       {isSelected && <TabOptions onClick={openMenu} />}
       {showTabMenu && (
-        <TabMenu onClose={closeMenu} setShowDetails={setShowDetails} />
+        <TabMenu
+          idx={idx}
+          name={name}
+          onClose={closeMenu}
+          setShowDetails={setShowDetails}
+        />
       )}
     </li>
   );

--- a/src/GroupTabs/GroupTabs.js
+++ b/src/GroupTabs/GroupTabs.js
@@ -35,7 +35,7 @@ function GroupTab({ idx, name, setShowConfirm, setShowDetails }) {
     const liElement = target.closest("li[data-index]");
     if (liElement && isPendingChanges) {
       setShowConfirm({ newIndex: liElement.dataset.index });
-    } else if (liElement) {
+    } else if (liElement && liElement.dataset.index !== currentGroupIndex) {
       setShowDetails(false);
       setShowDials(false);
       updateSetting("currentGroupIndex", liElement.dataset.index);

--- a/src/GroupTabs/TabMenu/TabMenu.js
+++ b/src/GroupTabs/TabMenu/TabMenu.js
@@ -1,13 +1,25 @@
 import { useEffect, useRef } from "react";
 
+import useGroupStore from "../../Stores/useGroupStore";
+
 import "./TabMenu.css";
 
-function TabMenu({ onClose, setShowDetails }) {
+function TabMenu({ idx, name, onClose, setShowDetails }) {
   const menuRef = useRef(null);
+  const [shiftGroup, getGroupsLength] = useGroupStore((state) => [
+    state.shiftGroup,
+    state.getGroupsLength,
+  ]);
 
   const openDetails = (event) => {
     event.stopPropagation();
     setShowDetails(true);
+    if (menuRef.current) menuRef.current.blur();
+  };
+
+  const handleShiftGroup = (steps, event) => {
+    event.stopPropagation();
+    shiftGroup(name, steps);
     if (menuRef.current) menuRef.current.blur();
   };
 
@@ -21,6 +33,12 @@ function TabMenu({ onClose, setShowDetails }) {
     <div ref={menuRef} className="TabMenu" onBlur={onClose} tabIndex={0}>
       <ul>
         <li onClick={openDetails}>Edit Group</li>
+        {idx !== 0 && (
+          <li onClick={(e) => handleShiftGroup(-1, e)}>Move Group Left</li>
+        )}
+        {idx !== getGroupsLength() - 1 && (
+          <li onClick={(e) => handleShiftGroup(1, e)}>Move Group Right</li>
+        )}
       </ul>
     </div>
   );

--- a/src/Stores/useGroupStore.js
+++ b/src/Stores/useGroupStore.js
@@ -11,7 +11,21 @@ const useGroupStore = create(
       getCurrentGroup: () => {
         return get().groups[useSettingStore.getState().currentGroupIndex];
       },
+      getGroupsLength: () => get().groups.length,
       setLoadedFromStorage: (value) => set({ loadedFromStorage: value }),
+      shiftGroup: (groupName, steps) => {
+        const newGroups = get().groups;
+        const groupIndex = newGroups.findIndex(
+          (group) => group.name === groupName,
+        );
+        const newIndex = groupIndex + steps;
+        if (0 <= newIndex && newIndex < newGroups.length) {
+          const [movedGroup] = newGroups.splice(groupIndex, 1);
+          newGroups.splice(newIndex, 0, movedGroup);
+          useSettingStore.getState().updateGroupIndex(newIndex);
+          set({ groups: newGroups });
+        }
+      },
       updateAllGroups: (groups) => set({ groups }),
       updateGroupDials: (groupName, newDials) => {
         set({

--- a/src/Stores/useSettingStore.js
+++ b/src/Stores/useSettingStore.js
@@ -16,9 +16,10 @@ const useSettingStore = create(
       updateAllSettings: (settings) => set({ ...settings }),
       updateGroupIndex: (newIndex) => {
         useRenderStore.getState().setShowDials(false);
-        set(() => {
-          currentGroupIndex: parseInt(newIndex);
-        });
+        set((state) => ({
+          ...state,
+          currentGroupIndex: parseInt(newIndex),
+        }));
       },
       updateSetting: (settingName, settingValue) =>
         set((state) => ({


### PR DESCRIPTION
## Summary

This PR addresses Issue #42 which requests the ability to reorder your using a simple "left" or "right" button in the `TabMenu`.

## Changes

- Updated monitoring of image loading to rely on `img.complete` rather than the image element's `onLoad` as there were some cases (refresh, double-click) where images aren't reloaded so relying on that mechanism to count was failing. Now I'm simply using a timer to check if all of the image elements are loaded, clearing the timer when they are, and proceeding as usual to reveal the dials.
- Added a `shiftGroup` function to `useGroupStore` to move a group a specified number of steps within the `groups` array then set the updated array to state.
- Corrected mistake I made in `updateGroupIndex`. I thought `set` used a merge approach to updating state but it looks like I have to explicitly spread out the existing state and update the whole object. This was causing some interesting errors to debug, noticed by checking the persist data in `localStorage` and observing everything was being wiped out.