### PR TITLE
Transfer Dial to Another Group

### DIFF
--- a/src/Confirm/Confirm.js
+++ b/src/Confirm/Confirm.js
@@ -5,16 +5,18 @@ export function Confirm({ message, options }) {
     <div className={`Confirm`}>
       <div className="popup">
         <p>{message}</p>
-        {options.map((option) => {
-          const buttonStyle = option.color
-            ? { backgroundColor: option.color }
-            : {};
-          return (
-            <button style={buttonStyle} onClick={option.action}>
-              {option.label}
-            </button>
-          );
-        })}
+        <div className="butonBox">
+          {options.map((option) => {
+            const buttonStyle = option.color
+              ? { backgroundColor: option.color }
+              : {};
+            return (
+              <button style={buttonStyle} onClick={option.action}>
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -26,8 +26,12 @@
   margin: 0 15px 0 10px;
 }
 
-.DialDetails .faTrash {
+.DialDetails .actionsBox {
   margin-left: auto;
-  margin-right: 15px;
+}
+
+.DialDetails .faTrash,
+.DialDetails .transfer {
   cursor: pointer;
+  margin-right: 15px;
 }

--- a/src/GroupDetails/GroupDetails.css
+++ b/src/GroupDetails/GroupDetails.css
@@ -28,10 +28,32 @@
 
 .DialDetails .actionsBox {
   margin-left: auto;
+  display: flex;
 }
 
 .DialDetails .faTrash,
 .DialDetails .transfer {
   cursor: pointer;
   margin-right: 15px;
+}
+
+.TransferDial button {
+  margin: 5px;
+  padding: 5px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.TransferDial .proceed {
+  background-color: #4caf50;
+}
+
+.TransferDial .cancel {
+  background-color: #f44336;
+}
+
+.TransferDial .buttonBox {
+  display: flex;
+  justify-content: space-between;
 }

--- a/src/GroupDetails/GroupDetails.js
+++ b/src/GroupDetails/GroupDetails.js
@@ -1,5 +1,8 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faTrash,
+  faArrowRightArrowLeft,
+} from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 
 import "./GroupDetails.css";
@@ -7,6 +10,10 @@ import { useGroupDetails } from "./useGroupDetails";
 import { ArrowSelector } from "../ArrowSelector/ArrowSelector";
 import { Confirm } from "../Confirm/Confirm";
 import { NewDialForm } from "../NewDialForm/NewDialForm";
+
+function TransferDial() {
+  return <FontAwesomeIcon className="transfer" icon={faArrowRightArrowLeft} />;
+}
 
 function DeleteDial({ index, shiftDial }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -54,7 +61,10 @@ function DialDetails({ index, first, last, name, icon, link, shiftDial }) {
         <p>{name}</p>
         <p>{link}</p>
       </div>
-      <DeleteDial index={index} shiftDial={shiftDial} />
+      <div className="actionsBox">
+        <TransferDial />
+        <DeleteDial index={index} shiftDial={shiftDial} />
+      </div>
     </li>
   );
 }

--- a/src/PopUpModal/PopUpModal.css
+++ b/src/PopUpModal/PopUpModal.css
@@ -1,4 +1,5 @@
-.Confirm {
+.PopUpModal {
+  color: black;
   position: fixed;
   top: 0;
   left: 0;
@@ -22,19 +23,7 @@
   text-align: center;
 }
 
-.popup button {
-  margin-top: 10px;
-  margin-right: 15px;
-  padding: 5px;
-  border: none;
-  border-radius: 5px;
-  background-color: #f4f4f4;
+.popup h1 {
   color: black;
-  cursor: pointer;
-  align-self: center;
-}
-
-.popup .buttonBox {
-  display: flex;
-  justify-content: center;
+  font-family: "Oxygen Mono", monospace;
 }

--- a/src/PopUpModal/PopUpModal.js
+++ b/src/PopUpModal/PopUpModal.js
@@ -1,0 +1,11 @@
+import "./PopUpModal.css";
+
+function PopUpModal({ children, options }) {
+  return (
+    <div className="PopUpModal">
+      <div className="popup">{children}</div>
+    </div>
+  );
+}
+
+export default PopUpModal;

--- a/src/Stores/useGroupStore.js
+++ b/src/Stores/useGroupStore.js
@@ -26,6 +26,21 @@ const useGroupStore = create(
           set({ groups: newGroups });
         }
       },
+      transferDial: (fromGroup, dial, toGroup) => {
+        const groups = get().groups.map((group) => {
+          if (group.name === fromGroup) {
+            return {
+              ...group,
+              dials: group.dials.filter((d) => d !== dial),
+            };
+          }
+          if (group.name === toGroup) {
+            return { ...group, dials: [...group.dials, dial] };
+          }
+          return group;
+        });
+        set({ groups });
+      },
       updateAllGroups: (groups) => set({ groups }),
       updateGroupDials: (groupName, newDials) => {
         set({


### PR DESCRIPTION
## Summary

This PR addresses Issue #24 which requests the ability to transfer an existing dial to another existing group.

## Changes

- Created a `PopUp` component with the goal of creating a more reusable modal like the `Confirm` that can wrap other elements. I should be able to refactor `Confirm` with this new component as well.
- Created a `TransferDial` component that handles rendering of a popup modal showing a list of the other group names the dial can be transferred to.
- When a dial is transferred it is an immediate action and doesn't wipe other pending changes to the group in the `GroupDetails` view.