### PR TITLE
Welcome Page

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -1,6 +1,6 @@
 #App {
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: #635e5e;
   background-size: cover;
   min-height: 100vh;
 }

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -3,19 +3,16 @@ import { Settings } from "../Settings/Settings";
 
 import "./App.css";
 import useApp from "./useApp";
-import NewGroupForm from "../Group/NewGroupForm/NewGroupForm";
 import Welcome from "../Welcome/Welcome";
 
 function App() {
-  const { background, getData, showSettings, showNewGroupForm, showWelcome } =
-    useApp();
+  const { background, getData, showSettings, showWelcome } = useApp();
 
   return (
     <div id="App" style={{ backgroundImage: `url("${background}")` }}>
       {showWelcome && <Welcome getData={getData} />}
       {showSettings && !showWelcome && <Settings getData={getData} />}
       {!showSettings && !showWelcome && <Dialer />}
-      {showNewGroupForm && <NewGroupForm />}
     </div>
   );
 }

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -4,13 +4,17 @@ import { Settings } from "../Settings/Settings";
 import "./App.css";
 import useApp from "./useApp";
 import NewGroupForm from "../Group/NewGroupForm/NewGroupForm";
+import Welcome from "../Welcome/Welcome";
 
 function App() {
-  const { background, getData, showSettings, showNewGroupForm } = useApp();
+  const { background, getData, showSettings, showNewGroupForm, showWelcome } =
+    useApp();
 
   return (
     <div id="App" style={{ backgroundImage: `url("${background}")` }}>
-      {showSettings ? <Settings getData={getData} /> : <Dialer />}
+      {showWelcome && <Welcome />}
+      {showSettings && !showWelcome && <Settings getData={getData} />}
+      {!showSettings && !showWelcome && <Dialer />}
       {showNewGroupForm && <NewGroupForm />}
     </div>
   );

--- a/src/App/App.js
+++ b/src/App/App.js
@@ -12,7 +12,7 @@ function App() {
 
   return (
     <div id="App" style={{ backgroundImage: `url("${background}")` }}>
-      {showWelcome && <Welcome />}
+      {showWelcome && <Welcome getData={getData} />}
       {showSettings && !showWelcome && <Settings getData={getData} />}
       {!showSettings && !showWelcome && <Dialer />}
       {showNewGroupForm && <NewGroupForm />}

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -37,10 +37,19 @@ function useApp() {
     }
   };
 
+  // Show the welcome screen if no settings or groups are in storage
   useEffect(() => {
     const missingFromStorage = !groupsfromStorage || !settingsFromStorage;
     setShowWelcome(missingFromStorage);
   }, [settingsFromStorage, groupsfromStorage]);
+
+  // Set the background image
+  useEffect(() => {
+    const appElement = document.getElementById("App");
+    if (appElement && background) {
+      appElement.style.backgroundImage = `url("${background}")`;
+    }
+  }, [background]);
 
   return {
     background,

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -39,10 +39,8 @@ function useApp() {
 
   useEffect(() => {
     const missingFromStorage = !groupsfromStorage || !settingsFromStorage;
-    if (missingFromStorage) {
-      setShowWelcome(true);
-    }
-  }, []);
+    setShowWelcome(missingFromStorage);
+  }, [settingsFromStorage, groupsfromStorage]);
 
   return {
     background,

--- a/src/App/useApp.js
+++ b/src/App/useApp.js
@@ -16,10 +16,13 @@ function useApp() {
     state.loadedFromStorage,
     state.updateAllGroups,
   ]);
-  const [showSettings, showNewGroupForm] = useRenderStore((state) => [
-    state.showSettings,
-    state.showNewGroupForm,
-  ]);
+  const [showSettings, showNewGroupForm, showWelcome, setShowWelcome] =
+    useRenderStore((state) => [
+      state.showSettings,
+      state.showNewGroupForm,
+      state.showWelcome,
+      state.setShowWelcome,
+    ]);
 
   const getData = async (configUrl) => {
     try {
@@ -37,8 +40,7 @@ function useApp() {
   useEffect(() => {
     const missingFromStorage = !groupsfromStorage || !settingsFromStorage;
     if (missingFromStorage) {
-      const configUrl = window.prompt("URL to JSON config file:");
-      getData(configUrl);
+      setShowWelcome(true);
     }
   }, []);
 
@@ -47,6 +49,7 @@ function useApp() {
     getData,
     showSettings,
     showNewGroupForm,
+    showWelcome,
   };
 }
 

--- a/src/Common/NavClose/NavClose.css
+++ b/src/Common/NavClose/NavClose.css
@@ -6,13 +6,11 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  padding-top: 5px;
 }
 
 .NavClose ul li {
-  position: relative;
-  top: -5px;
   border: 1px solid white;
-  border-top: none;
   border-radius: 5px;
   height: 40px;
   padding: 10px;

--- a/src/Common/NavClose/NavClose.js
+++ b/src/Common/NavClose/NavClose.js
@@ -7,7 +7,7 @@ export default function NavClose({ onClose }) {
   return (
     <nav className="NavClose">
       <ul>
-        <li>
+        <li title="Close Settings">
           <FontAwesomeIcon onClick={onClose} icon={faRectangleXmark} />
         </li>
       </ul>

--- a/src/Dial/Dial.js
+++ b/src/Dial/Dial.js
@@ -1,6 +1,6 @@
 function Dial({ icon, name, link }, key) {
   return (
-    <a href={link} key={key}>
+    <a href={link} key={key} title={name}>
       <img src={icon} alt={name} />
     </a>
   );

--- a/src/DialOperations/NewDialForm/NewDialForm.js
+++ b/src/DialOperations/NewDialForm/NewDialForm.js
@@ -3,16 +3,16 @@ import { useState } from "react";
 import PopUpModal from "../../Common/PopUpModal/PopUpModal";
 
 function NewDialForm({ insertNewDial, setShowAddDial }) {
-  const [name, setName] = useState("");
+  const [dialName, setDialName] = useState("");
   const [icon, setIcon] = useState("");
   const [link, setLink] = useState("");
 
-  const handleNameChange = (e) => setName(e.target.value);
+  const handleDialNameChange = (e) => setDialName(e.target.value);
   const handleIconChange = (e) => setIcon(e.target.value);
   const handleLinkChange = (e) => setLink(e.target.value);
 
   const handleAdd = () => {
-    insertNewDial(name, icon, link);
+    insertNewDial(dialName, icon, link);
     setShowAddDial(false);
   };
 
@@ -21,12 +21,12 @@ function NewDialForm({ insertNewDial, setShowAddDial }) {
       <div className="NewDialForm">
         <h2>New Dial</h2>
         <div>
-          <label>Name</label>
+          <label>Dial Name</label>
           <input
             type="text"
-            placeholder="Name"
-            value={name}
-            onChange={handleNameChange}
+            placeholder="Dial Name"
+            value={dialName}
+            onChange={handleDialNameChange}
           />
         </div>
         <div>

--- a/src/Dialer/Dialer.js
+++ b/src/Dialer/Dialer.js
@@ -2,11 +2,13 @@ import Group from "../Group/Group";
 import GroupDetails from "../GroupDetails/GroupDetails";
 import GroupTabs from "../GroupTabs/GroupTabs";
 import Time from "../Time/Time";
+import NewGroupForm from "../Group/NewGroupForm/NewGroupForm";
 
 import { useDialer } from "./useDialer";
 
 export default function Dialer() {
-  const { showDialDetails, timeEnabled, timeFormat } = useDialer();
+  const { showDialDetails, showNewGroupForm, timeEnabled, timeFormat } =
+    useDialer();
 
   return (
     <>
@@ -15,6 +17,8 @@ export default function Dialer() {
       {timeEnabled && <Time timeFormat={timeFormat} />}
 
       {showDialDetails ? <GroupDetails /> : <Group />}
+
+      {showNewGroupForm && <NewGroupForm />}
     </>
   );
 }

--- a/src/Dialer/useDialer.js
+++ b/src/Dialer/useDialer.js
@@ -2,7 +2,10 @@ import useSettingStore from "../Stores/useSettingStore";
 import useRenderStore from "../Stores/useRenderStore";
 
 export function useDialer() {
-  const [showDialDetails] = useRenderStore((state) => [state.showDialDetails]);
+  const [showDialDetails, showNewGroupForm] = useRenderStore((state) => [
+    state.showDialDetails,
+    state.showNewGroupForm,
+  ]);
   const [timeEnabled, timeFormat] = useSettingStore((state) => [
     state.timeEnabled,
     state.timeFormat,
@@ -10,6 +13,7 @@ export function useDialer() {
 
   return {
     showDialDetails,
+    showNewGroupForm,
     timeEnabled,
     timeFormat,
   };

--- a/src/Group/Group.css
+++ b/src/Group/Group.css
@@ -36,3 +36,16 @@
   max-width: 150px;
   margin: 40px;
 }
+
+.emptyGroupNotice {
+  position: absolute;
+  top: 45vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 24px;
+  color: #fff;
+  padding: 20px;
+  background-color: #0f0f0f;
+  border-radius: 10px;
+}

--- a/src/Group/Group.js
+++ b/src/Group/Group.js
@@ -7,9 +7,15 @@ function Group() {
 
   return (
     <div className={`Group ${showDials ? "fade-in" : "fade-out"}`}>
-      {dials.map((dialData, index) => {
-        return <Dial {...dialData} key={index} />;
-      })}
+      {dials &&
+        dials.map((dialData, index) => {
+          return <Dial {...dialData} key={index} />;
+        })}
+      {dials.length === 0 && (
+        <div className="emptyGroupNotice">
+          Edit the group above to add a dial.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/Group/useGroup.js
+++ b/src/Group/useGroup.js
@@ -40,7 +40,7 @@ function useGroup() {
     if (timeoutId) {
       return () => clearTimeout(timeoutId);
     }
-  }, [currentGroupIndex]);
+  }, [currentGroupIndex, groups]);
 
   if (!currentGroup) {
     return { dials: [] };

--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -7,6 +7,7 @@
   position: sticky;
   top: 0;
   z-index: 100;
+  padding-top: 5px;
 }
 
 .GroupTabs ul {

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGear, faRefresh } from "@fortawesome/free-solid-svg-icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import NavClose from "../Common/NavClose/NavClose";
 import useSettingStore from "../Stores/useSettingStore";
@@ -36,27 +36,46 @@ export function SettingsTab() {
 }
 
 export function Settings({ getData }) {
-  const [configUrl, timeEnabled, timeFormat, updateSetting] = useSettingStore(
-    (state) => {
+  const [background, configUrl, timeEnabled, timeFormat, updateSetting] =
+    useSettingStore((state) => {
       return [
+        state.background,
         state.configUrl,
         state.timeEnabled,
         state.timeFormat,
         state.updateSetting,
       ];
-    },
-  );
+    });
   const [setShowSettings] = useRenderStore((state) => [state.setShowSettings]);
-  const [urlInputValue, setUrlInputValue] = useState(configUrl);
+  const [configUrlInputValue, setConfigUrlInputValue] = useState(configUrl);
+  const [backgroundUrlInputValue, setBackgroundUrlInputValue] =
+    useState(background);
+
+  useEffect(() => {
+    const newBackgroundUrl = document.getElementById("background");
+    const applyBackgroundButton = document.getElementById(
+      "applyBackgroundButton",
+    );
+    applyBackgroundButton.disabled = newBackgroundUrl.value === background;
+  }, [background, backgroundUrlInputValue]);
 
   const handleConfigRefresh = () => {
     const newUrl = document.getElementById("config-url");
     getData(newUrl.value);
   };
 
-  const handleUrlChange = () => {
+  const handleConfigUrlChange = () => {
     const current = document.getElementById("config-url").value;
-    setUrlInputValue(current);
+    setConfigUrlInputValue(current);
+  };
+
+  const handleBackgroundUrlChange = () => {
+    const newUrl = document.getElementById("background").value;
+    setBackgroundUrlInputValue(newUrl);
+  };
+
+  const handleSetBakcground = () => {
+    updateSetting("background", backgroundUrlInputValue);
   };
 
   return (
@@ -64,13 +83,24 @@ export function Settings({ getData }) {
       <NavClose onClose={() => setShowSettings(false)} />
       <div className="Settings">
         <h1>Settings</h1>
+        <h2>Background</h2>
+        <input
+          type="text"
+          label="background"
+          id="background"
+          value={backgroundUrlInputValue}
+          onChange={handleBackgroundUrlChange}
+        />
+        <button id="applyBackgroundButton" onClick={handleSetBakcground}>
+          Apply Background
+        </button>
         <h2>Config File URL</h2>
         <input
           type="text"
           label="configURL"
           id="config-url"
-          value={urlInputValue}
-          onChange={handleUrlChange}
+          value={configUrlInputValue}
+          onChange={handleConfigUrlChange}
         />
         <FontAwesomeIcon
           onClick={handleConfigRefresh}

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -28,7 +28,7 @@ export function SettingsTab() {
   }
   return (
     <ul style={{ marginBottom: "auto" }}>
-      <li>
+      <li title="Open Settings">
         <FontAwesomeIcon onClick={handleClick} icon={faGear} />
       </li>
     </ul>

--- a/src/Settings/TimeSettings/TimeSettings.js
+++ b/src/Settings/TimeSettings/TimeSettings.js
@@ -13,6 +13,7 @@ export function TimeSettings({ timeEnabled, timeFormat, updateSetting }) {
 
   return (
     <div id="TimeSettings">
+      <h2>Time Settings</h2>
       <div>
         <label for="time-enabled">Show Time</label>
         <select

--- a/src/Stores/useGroupStore.js
+++ b/src/Stores/useGroupStore.js
@@ -20,6 +20,12 @@ const useGroupStore = create(
           groups: [...get().groups, { name: groupName, dials: [] }],
         });
       },
+      createInitialGroup: () => {
+        set({
+          ...get().state,
+          groups: [{ name: "Default", dials: [] }],
+        });
+      },
       deleteGroup: (groupName) => {
         const newGroups = get().groups.filter(
           (group) => group.name !== groupName,

--- a/src/Stores/useRenderStore.js
+++ b/src/Stores/useRenderStore.js
@@ -8,6 +8,8 @@ const useRenderStore = create((set) => ({
   nextIndex: null,
   showNewGroupForm: false,
   showDialDetails: false,
+  showWelcome: true,
+  setShowWelcome: (value) => set({ showWelcome: value }),
   setShowDialDetails: (value) => set({ showDialDetails: value }),
   setShowNewGroupForm: (value) => set({ showNewGroupForm: value }),
   setNextIndex: (value) => set({ nextIndex: value }),

--- a/src/Stores/useRenderStore.js
+++ b/src/Stores/useRenderStore.js
@@ -8,7 +8,7 @@ const useRenderStore = create((set) => ({
   nextIndex: null,
   showNewGroupForm: false,
   showDialDetails: false,
-  showWelcome: true,
+  showWelcome: false,
   setShowWelcome: (value) => set({ showWelcome: value }),
   setShowDialDetails: (value) => set({ showDialDetails: value }),
   setShowNewGroupForm: (value) => set({ showNewGroupForm: value }),

--- a/src/Welcome/Welcome.css
+++ b/src/Welcome/Welcome.css
@@ -1,0 +1,9 @@
+.Welcome h2 {
+  font-size: 24px;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.Welcome button {
+  margin: 10px;
+}

--- a/src/Welcome/Welcome.js
+++ b/src/Welcome/Welcome.js
@@ -1,0 +1,54 @@
+import "./Welcome.css";
+import PopUpModal from "../Common/PopUpModal/PopUpModal";
+import useGroupStore from "../Stores/useGroupStore";
+import useRenderStore from "../Stores/useRenderStore";
+import useSettingStore from "../Stores/useSettingStore";
+
+function useWelcome() {
+  const [createInitialGroup] = useGroupStore((state) => [
+    state.createInitialGroup,
+  ]);
+  const [setShowWelcome, setShowDialDetails] = useRenderStore((state) => [
+    state.setShowWelcome,
+    state.setShowDialDetails,
+  ]);
+  const [updateGroupIndex] = useSettingStore((state) => [
+    state.updateGroupIndex,
+  ]);
+
+  const handleCreateGroup = () => {
+    createInitialGroup();
+    setShowWelcome(false);
+    updateGroupIndex(0);
+    setShowDialDetails(true);
+  };
+
+  return {
+    handleCreateGroup,
+  };
+}
+
+function Welcome() {
+  const { handleCreateGroup } = useWelcome();
+
+  return (
+    <PopUpModal>
+      <div className="Welcome">
+        <h2>Welcome to New Tab Dialer</h2>
+        <p>You can get started by creating your first group, </p>
+        <button className="green" onClick={handleCreateGroup}>
+          Create a Group
+        </button>
+        <p>Or supply a link to a config file:</p>
+        <input
+          type="text"
+          id="configUrl"
+          placeholder="https://example.com/config.json"
+        />
+        <button className="green">Load Config</button>
+      </div>
+    </PopUpModal>
+  );
+}
+
+export default Welcome;

--- a/src/Welcome/Welcome.js
+++ b/src/Welcome/Welcome.js
@@ -4,7 +4,7 @@ import useGroupStore from "../Stores/useGroupStore";
 import useRenderStore from "../Stores/useRenderStore";
 import useSettingStore from "../Stores/useSettingStore";
 
-function useWelcome() {
+function useWelcome(getData) {
   const [createInitialGroup] = useGroupStore((state) => [
     state.createInitialGroup,
   ]);
@@ -23,13 +23,20 @@ function useWelcome() {
     setShowDialDetails(true);
   };
 
+  const handleLoadConfig = () => {
+    const configUrl = document.getElementById("configUrl").value;
+    getData(configUrl);
+    setShowWelcome(false);
+  };
+
   return {
     handleCreateGroup,
+    handleLoadConfig,
   };
 }
 
-function Welcome() {
-  const { handleCreateGroup } = useWelcome();
+function Welcome({ getData }) {
+  const { handleCreateGroup, handleLoadConfig } = useWelcome(getData);
 
   return (
     <PopUpModal>
@@ -45,7 +52,9 @@ function Welcome() {
           id="configUrl"
           placeholder="https://example.com/config.json"
         />
-        <button className="green">Load Config</button>
+        <button className="green" onClick={handleLoadConfig}>
+          Load Config
+        </button>
       </div>
     </PopUpModal>
   );


### PR DESCRIPTION
## Summary

This PR addresses Issue #53 which requests a starting/landing page for the extension when there is no data in `localStorage` for Zustand to rehydrate.

## Changes

- Created a `Welcome` component that renders when Zustand's Persist integration is unable to rehydrate a full configuration (group and settings) from `localStorage`. This allows a user to set up their first group or load a config from a URL.
- Added `createInitialGroup` to the `useGroupStore` to handle creation of a default group for a user starting from scratch.
- Changed input label in `NewDialForm` from `name` to `dialName` because it seems to trigger 3rd party extensions that look for inputs used to log in a user.
- Moved `NewGroupForm` into the dialer, it didn't make sense rendering at the `App` level.
- Style adjustments to the `Settings` component.
- Added tooltips to `Dial`, `SettingsTab`, and `NavClose`.
- Added background image input to `Settings`.
- Added a notice to `Group` when the `groups` array is empty prompting the user to edit the group to add a dial.