### PR TITLE
Export Config to File

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -1,8 +1,0 @@
-chrome.runtime.onMessage.addListener(({event, value}) => {
-  if (event === "promptDownload") {
-    chrome.downloads.download({
-      url: value,
-      filename: "dialer-config.json",
-    });
-  }
-});

--- a/public/background.js
+++ b/public/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener(({event, value}) => {
+  if (event === "promptDownload") {
+    chrome.downloads.download({
+      url: value,
+      filename: "dialer-config.json",
+    });
+  }
+});

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,5 +4,6 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
-  "manifest_version": 3
+  "manifest_version": 3,
+  "permissions": ["downloads"]
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,8 +5,5 @@
     "newtab": "index.html"
   },
   "manifest_version": 3,
-  "permissions": ["downloads"],
-  "background": {
-    "service_worker": "background.js"
-  }
+  "permissions": ["downloads"]
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,5 +5,8 @@
     "newtab": "index.html"
   },
   "manifest_version": 3,
-  "permissions": ["downloads"]
+  "permissions": ["downloads"],
+  "background": {
+    "service_worker": "background.js"
+  }
 }

--- a/src/Settings/Settings.css
+++ b/src/Settings/Settings.css
@@ -2,16 +2,26 @@
   color: white;
   font-size: 24px;
   margin-bottom: 20px;
+  margin-left: 20px;
 }
 
 .Settings h2 {
   color: white;
   font-size: 16px;
-  margin-bottom: 5px;
+  margin-bottom: 10px;
 }
 
+.Settings > div {
+  background-color: rgb(0, 0, 0, 0.6);
+  margin: 0 10px 20px 10px;
+  padding: 20px;
+  max-width: fit-content;
+  border-radius: 5px;
+}
+
+#background,
 #config-url {
-  width: 33%;
+  width: 400px;
 }
 
 .Settings {
@@ -19,7 +29,8 @@
   color: white;
 }
 
-.refresh-icon {
+.refresh-icon,
+.download-icon {
   color: white;
   margin-left: 5px;
 }

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -84,6 +84,10 @@ export function Settings({ getData }) {
     };
     const encodedData = window.btoa(JSON.stringify(data, null, 2));
     const dataUrl = `data:application/json;base64,${encodedData}`;
+    window.chrome.runtime.sendMessage({
+      event: "promptDownload",
+      value: dataUrl,
+    });
     console.log(dataUrl);
   };
 

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -1,9 +1,14 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGear, faRefresh } from "@fortawesome/free-solid-svg-icons";
+import {
+  faFileArrowDown,
+  faGear,
+  faRefresh,
+} from "@fortawesome/free-solid-svg-icons";
 import { useEffect, useState } from "react";
 
 import NavClose from "../Common/NavClose/NavClose";
 import useSettingStore from "../Stores/useSettingStore";
+import useGroupStore from "../Stores/useGroupStore";
 import useRenderStore from "../Stores/useRenderStore";
 
 import "./Settings.css";
@@ -70,6 +75,18 @@ export function Settings({ getData }) {
     updateSetting("background", backgroundUrlInputValue);
   };
 
+  const promptDownload = () => {
+    const groups = useGroupStore.getState().export();
+    const settings = useSettingStore.getState().export();
+    const data = {
+      groups,
+      settings,
+    };
+    const encodedData = window.btoa(JSON.stringify(data, null, 2));
+    const dataUrl = `data:application/json;base64,${encodedData}`;
+    console.log(dataUrl);
+  };
+
   return (
     <>
       <NavClose onClose={() => setShowSettings(false)} />
@@ -98,6 +115,11 @@ export function Settings({ getData }) {
           onClick={handleConfigRefresh}
           icon={faRefresh}
           className="refresh-icon"
+        />
+        <FontAwesomeIcon
+          icon={faFileArrowDown}
+          className="download-icon"
+          onClick={promptDownload}
         />
         <TimeSettings
           timeEnabled={timeEnabled}

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -4,15 +4,13 @@ import {
   faGear,
   faRefresh,
 } from "@fortawesome/free-solid-svg-icons";
-import { useEffect, useState } from "react";
 
 import NavClose from "../Common/NavClose/NavClose";
-import useSettingStore from "../Stores/useSettingStore";
-import useGroupStore from "../Stores/useGroupStore";
 import useRenderStore from "../Stores/useRenderStore";
 
 import "./Settings.css";
-import { TimeSettings } from "./TimeSettings/TimeSettings";
+import useSettings from "./useSettings";
+import TimeSettings from "./TimeSettings/TimeSettings";
 
 export function SettingsTab() {
   const [setShowSettings] = useRenderStore((state) => {
@@ -33,98 +31,60 @@ export function SettingsTab() {
 }
 
 export function Settings({ getData }) {
-  const [background, configUrl, timeEnabled, timeFormat, updateSetting] =
-    useSettingStore((state) => {
-      return [
-        state.background,
-        state.configUrl,
-        state.timeEnabled,
-        state.timeFormat,
-        state.updateSetting,
-      ];
-    });
-  const [setShowSettings] = useRenderStore((state) => [state.setShowSettings]);
-  const [configUrlInputValue, setConfigUrlInputValue] = useState(configUrl);
-  const [backgroundUrlInputValue, setBackgroundUrlInputValue] =
-    useState(background);
-
-  useEffect(() => {
-    const newBackgroundUrl = document.getElementById("background");
-    const applyBackgroundButton = document.getElementById(
-      "applyBackgroundButton",
-    );
-    applyBackgroundButton.disabled = newBackgroundUrl.value === background;
-  }, [background, backgroundUrlInputValue]);
-
-  const handleConfigRefresh = () => {
-    const newUrl = document.getElementById("config-url");
-    getData(newUrl.value);
-  };
-
-  const handleConfigUrlChange = () => {
-    const current = document.getElementById("config-url").value;
-    setConfigUrlInputValue(current);
-  };
-
-  const handleBackgroundUrlChange = () => {
-    const newUrl = document.getElementById("background").value;
-    setBackgroundUrlInputValue(newUrl);
-  };
-
-  const handleSetBakcground = () => {
-    updateSetting("background", backgroundUrlInputValue);
-  };
-
-  const promptDownload = () => {
-    const groups = useGroupStore.getState().export();
-    const settings = useSettingStore.getState().export();
-    const data = {
-      groups,
-      settings,
-    };
-    const encodedData = window.btoa(JSON.stringify(data, null, 2));
-    const dataUrl = `data:application/json;base64,${encodedData}`;
-    window.chrome.runtime.sendMessage({
-      event: "promptDownload",
-      value: dataUrl,
-    });
-    console.log(dataUrl);
-  };
+  const {
+    backgroundUrlInputValue,
+    configUrlInputValue,
+    handleConfigRefresh,
+    handleConfigUrlChange,
+    handleBackgroundUrlChange,
+    handleSetBakcground,
+    promptDownload,
+    setShowSettings,
+    timeEnabled,
+    timeFormat,
+    updateSetting,
+  } = useSettings(getData);
 
   return (
     <>
       <NavClose onClose={() => setShowSettings(false)} />
       <div className="Settings">
         <h1>Settings</h1>
-        <h2>Background</h2>
-        <input
-          type="text"
-          label="background"
-          id="background"
-          value={backgroundUrlInputValue}
-          onChange={handleBackgroundUrlChange}
-        />
-        <button id="applyBackgroundButton" onClick={handleSetBakcground}>
-          Apply Background
-        </button>
-        <h2>Config File URL</h2>
-        <input
-          type="text"
-          label="configURL"
-          id="config-url"
-          value={configUrlInputValue}
-          onChange={handleConfigUrlChange}
-        />
-        <FontAwesomeIcon
-          onClick={handleConfigRefresh}
-          icon={faRefresh}
-          className="refresh-icon"
-        />
-        <FontAwesomeIcon
-          icon={faFileArrowDown}
-          className="download-icon"
-          onClick={promptDownload}
-        />
+        <div>
+          <h2>Background</h2>
+          <input
+            type="text"
+            label="background"
+            id="background"
+            value={backgroundUrlInputValue}
+            onChange={handleBackgroundUrlChange}
+          />
+          <button id="applyBackgroundButton" onClick={handleSetBakcground}>
+            Apply Background
+          </button>
+        </div>
+        <div>
+          <h2>Config File URL</h2>
+          <input
+            type="text"
+            label="configURL"
+            id="config-url"
+            value={configUrlInputValue}
+            onChange={handleConfigUrlChange}
+          />
+          <FontAwesomeIcon
+            onClick={handleConfigRefresh}
+            icon={faRefresh}
+            className="refresh-icon"
+            title="Downstream Config Sync"
+          />
+          <FontAwesomeIcon
+            icon={faFileArrowDown}
+            className="download-icon"
+            onClick={promptDownload}
+            title="Download Config File"
+          />
+        </div>
         <TimeSettings
           timeEnabled={timeEnabled}
           timeFormat={timeFormat}

--- a/src/Settings/TimeSettings/TimeSettings.js
+++ b/src/Settings/TimeSettings/TimeSettings.js
@@ -1,6 +1,6 @@
 import "./TimeSettings.css";
 
-export function TimeSettings({ timeEnabled, timeFormat, updateSetting }) {
+function TimeSettings({ timeEnabled, timeFormat, updateSetting }) {
   const updateTimeEnabled = (event) => {
     const newValue = event.target.value === "true" ? true : false;
     updateSetting("timeEnabled", newValue);
@@ -39,3 +39,5 @@ export function TimeSettings({ timeEnabled, timeFormat, updateSetting }) {
     </div>
   );
 }
+
+export default TimeSettings;

--- a/src/Settings/useSettings.js
+++ b/src/Settings/useSettings.js
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import useSettingStore from "../Stores/useSettingStore";
+import useRenderStore from "../Stores/useRenderStore";
+import useGroupStore from "../Stores/useGroupStore";
+
+function useSettings({ getData }) {
+  const [background, configUrl, timeEnabled, timeFormat, updateSetting] =
+    useSettingStore((state) => {
+      return [
+        state.background,
+        state.configUrl,
+        state.timeEnabled,
+        state.timeFormat,
+        state.updateSetting,
+      ];
+    });
+  const [setShowSettings] = useRenderStore((state) => [state.setShowSettings]);
+  const [configUrlInputValue, setConfigUrlInputValue] = useState(configUrl);
+  const [backgroundUrlInputValue, setBackgroundUrlInputValue] =
+    useState(background);
+
+  useEffect(() => {
+    const newBackgroundUrl = document.getElementById("background");
+    const applyBackgroundButton = document.getElementById(
+      "applyBackgroundButton",
+    );
+    applyBackgroundButton.disabled = newBackgroundUrl.value === background;
+  }, [background, backgroundUrlInputValue]);
+
+  const handleConfigRefresh = () => {
+    const newUrl = document.getElementById("config-url");
+    getData(newUrl.value);
+  };
+
+  const handleConfigUrlChange = () => {
+    const current = document.getElementById("config-url").value;
+    setConfigUrlInputValue(current);
+  };
+
+  const handleBackgroundUrlChange = () => {
+    const newUrl = document.getElementById("background").value;
+    setBackgroundUrlInputValue(newUrl);
+  };
+
+  const handleSetBakcground = () => {
+    updateSetting("background", backgroundUrlInputValue);
+  };
+
+  const promptDownload = () => {
+    const groups = useGroupStore.getState().export();
+    const settings = useSettingStore.getState().export();
+    const data = {
+      groups,
+      settings,
+    };
+    const encodedData = window.btoa(JSON.stringify(data, null, 2));
+    const dataUrl = `data:application/json;base64,${encodedData}`;
+    window.chrome.runtime.sendMessage({
+      event: "promptDownload",
+      value: dataUrl,
+    });
+  };
+
+  return {
+    backgroundUrlInputValue,
+    configUrlInputValue,
+    handleConfigRefresh,
+    handleConfigUrlChange,
+    handleBackgroundUrlChange,
+    handleSetBakcground,
+    promptDownload,
+    setShowSettings,
+    timeEnabled,
+    timeFormat,
+    updateSetting,
+  };
+}
+
+export default useSettings;

--- a/src/Settings/useSettings.js
+++ b/src/Settings/useSettings.js
@@ -55,9 +55,9 @@ function useSettings({ getData }) {
     };
     const encodedData = window.btoa(JSON.stringify(data, null, 2));
     const dataUrl = `data:application/json;base64,${encodedData}`;
-    window.chrome.runtime.sendMessage({
-      event: "promptDownload",
-      value: dataUrl,
+    window.chrome.downloads.download({
+      url: dataUrl,
+      filename: "dialer-config.json",
     });
   };
 

--- a/src/Stores/useGroupStore.js
+++ b/src/Stores/useGroupStore.js
@@ -35,6 +35,7 @@ const useGroupStore = create(
           groups: newGroups,
         });
       },
+      export: () => get().groups,
       shiftGroup: (groupName, steps) => {
         const newGroups = get().groups;
         const groupIndex = newGroups.findIndex(

--- a/src/Stores/useSettingStore.js
+++ b/src/Stores/useSettingStore.js
@@ -5,7 +5,7 @@ import useRenderStore from "./useRenderStore";
 
 const useSettingStore = create(
   persist(
-    (set) => ({
+    (set, get) => ({
       background: "",
       configUrl: "",
       timeEnabled: false,
@@ -13,6 +13,15 @@ const useSettingStore = create(
       currentGroupIndex: 0,
       loadedFromStorage: false,
       setLoadedFromStorage: (value) => set({ loadedFromStorage: value }),
+      export: () => {
+        return {
+          background: get().background,
+          configUrl: get().configUrl,
+          timeEnabled: get().timeEnabled,
+          timeFormat: get().timeFormat,
+          currentGroupIndex: get().currentGroupIndex,
+        };
+      },
       updateAllSettings: (settings) => set({ ...settings }),
       updateGroupIndex: (newIndex) => {
         useRenderStore.getState().setShowDials(false);


### PR DESCRIPTION
## Summary

This PR addresses Issue #15 which requests the ability for a user to download their current extension configuration as a JSON file to their Downloads.

This was a very interesting look into the inner workings of Chrome Extensions, their lifecycle, and their service workers. I was not aware of the careful separation between the browser, extensions, and Chrome's various APIs. Very cool. Main challenge was realizing that the `chrome` runtime methods are only available to the app when it is being run as an installed extension within Chrome, adding some time to each round of manual testing.

## Changes

- Created an `export` method for both the `useSettingStore` and `useGroupStore` to easily get details needed in the exported config file.
- Due to limitations with creating URLs for Blobs in manifest version 3 for Chrome Extensions the config's JSON is base64 encoded and made into a Data URL for Chrome to download. There are tradeoffs to this approach such as an up to 30% increase in data size after encoding but the config is small and simple enough that this infrequent operation shouldn't be a major issue.
- Refactored `Settings` to separate logic into a `useSettings` custom hook.
- Touched up the styling and tooltips on the `Settings` view.
- An initial approach used a background worker but after wrapping my head around things I realized nothing in my app is actually running within the background, and my previous issues with accessing `chrome` were due to the app running on live-server during testing and not being installed to Chrome (where the extra features like `chrome.downloads` are accessible). After installing my app for testing it was able to access `window.chrome` and any Chrome API methods required from that point onward so I removed the unnecessary `background.js` I was using.