### PR TITLE
BUG Fixes CSS filter function capturing popup modal

### DIFF
--- a/src/Dial/DialDetails.css
+++ b/src/Dial/DialDetails.css
@@ -1,6 +1,6 @@
 .DialDetails {
   background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(5px);
+  /* backdrop-filter: blur(5px); */
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
## Summary

This PR addresses a bug caused by the addition of the `blur` function in the CSS styling of the `DialDetail` component. Turns out that using a filter function on an element captures any child elements within it when they attempt to use absolute positioning. This caused the `PopUpModal` to shift down and to the right to align with the list item with the dial details.

The solution for now is to just comment out the filter and use the previous styling. If blur if brought back then the `PopUpModal` components used for dial operations will need to be refactored so they are not present within the list items. 