### PR TITLE
Fix Renaming Group Workflow

### DIFF
--- a/src/Common/PopUpModal/PopUpModal.css
+++ b/src/Common/PopUpModal/PopUpModal.css
@@ -30,7 +30,7 @@
 .PopUpModal h2 {
   color: black;
   font-family: "Oxygen Mono", monospace;
-  margin-bottom: 15px;
+  padding: 10px;
 }
 
 .PopUpModal button {

--- a/src/Group/EditGroupName/EditGroupName.css
+++ b/src/Group/EditGroupName/EditGroupName.css
@@ -1,0 +1,10 @@
+.EditGroupName {
+  display: flex;
+  justify-content: center;
+}
+
+.EditGroupNameHeader {
+  font-family: "Oxygen Mono", monospace;
+  font-size: 24px;
+  padding: 15px;
+}

--- a/src/Group/EditGroupName/EditGroupName.js
+++ b/src/Group/EditGroupName/EditGroupName.js
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPencil } from "@fortawesome/free-solid-svg-icons";
+
+import PopUpModal from "../../Common/PopUpModal/PopUpModal";
+import useGroupStore from "../../Stores/useGroupStore";
+
+import "./EditGroupName.css";
+
+function useEditGroupName(groupName) {
+  const [renameGroup, getGroupNames] = useGroupStore((state) => {
+    return [state.renameGroup, state.getGroupNames];
+  });
+  const [tempName, setTempName] = useState(groupName ? groupName : "");
+  const [showEdit, setShowEdit] = useState(false);
+  const [restrictRename, setRestrictRename] = useState(true);
+
+  const handleNameSave = () => {
+    renameGroup(groupName, tempName);
+    setShowEdit(false);
+  };
+
+  const handleInputChange = (event) => {
+    event.preventDefault();
+    const existingNames = getGroupNames();
+    const newName = event.target.value;
+    setTempName(newName);
+    const createButton = document.getElementById("renameGroupSave");
+
+    if (newName === "") {
+      createButton.title = "Name cannot be empty";
+      setRestrictRename(true);
+    } else if (existingNames.includes(newName)) {
+      createButton.title = "Name already exists";
+      setRestrictRename(true);
+    } else {
+      createButton.title = "";
+      setRestrictRename(false);
+    }
+  };
+
+  return {
+    tempName,
+    showEdit,
+    setShowEdit,
+    handleNameSave,
+    handleInputChange,
+    restrictRename,
+  };
+}
+
+function EditGroupName({ groupName }) {
+  const {
+    tempName,
+    showEdit,
+    setShowEdit,
+    handleNameSave,
+    handleInputChange,
+    restrictRename,
+  } = useEditGroupName(groupName);
+  return (
+    <div className="EditGroupName">
+      <h2 className="EditGroupNameHeader">{groupName}</h2>
+      <FontAwesomeIcon
+        icon={faPencil}
+        onClick={() => setShowEdit(!showEdit)}
+        style={{ alignSelf: "center" }}
+      />
+      {showEdit && (
+        <PopUpModal>
+          <h2>Edit Group Name</h2>
+          <div>
+            <label>Group Name</label>
+            <input
+              id="groupName"
+              type="text"
+              value={tempName}
+              onChange={handleInputChange}
+            />
+          </div>
+          <div className="buttonBox">
+            <button className="red" onClick={() => setShowEdit(false)}>
+              Cancel
+            </button>
+            <button
+              className="green"
+              id="renameGroupSave"
+              onClick={handleNameSave}
+              disabled={restrictRename}
+            >
+              Save
+            </button>
+          </div>
+        </PopUpModal>
+      )}
+    </div>
+  );
+}
+
+export default EditGroupName;

--- a/src/Group/GroupDetails/GroupDetails.js
+++ b/src/Group/GroupDetails/GroupDetails.js
@@ -3,6 +3,7 @@ import { useGroupDetails } from "./useGroupDetails";
 import Confirm from "../../Common/Confirm/Confirm";
 import NewDialForm from "../../Dial/DialOperations/NewDialForm/NewDialForm";
 import DialDetails from "../../Dial/DialDetails";
+import EditGroupName from "../EditGroupName/EditGroupName";
 
 function GroupDetails() {
   const {
@@ -15,16 +16,11 @@ function GroupDetails() {
     showConfirmDelete,
     setShowAddDial,
     setShowConfirmDelete,
-    tempName,
-    handleNameInput,
   } = useGroupDetails();
 
   return (
     <div className="GroupDetails">
-      <div className="GroupName">
-        <h1>Group Name:</h1>
-        <input type="text" value={tempName} onChange={handleNameInput} />
-      </div>
+      <EditGroupName groupName={groupName} />
       {showAddDial && (
         <NewDialForm
           insertNewDial={insertNewDial}

--- a/src/Stores/useGroupStore.js
+++ b/src/Stores/useGroupStore.js
@@ -36,6 +36,16 @@ const useGroupStore = create(
         });
       },
       export: () => get().groups,
+      renameGroup: (groupName, newGroupName) => {
+        const newGroups = get().groups.map((group) => {
+          if (group.name === groupName) {
+            return { ...group, name: newGroupName };
+          } else {
+            return group;
+          }
+        });
+        set({ groups: newGroups });
+      },
       shiftGroup: (groupName, steps) => {
         const newGroups = get().groups;
         const groupIndex = newGroups.findIndex(


### PR DESCRIPTION
## Summary

This PR addresses Issue #68 which requests a fix for the ability to rename an existing group. This was broken after a refactoring of the `PopUpModal` and was missed because I admittedly am missing testing which is becoming more critical to future changes without regression.

## Changes

- Created an `EditGroupName` component to hold the form and logic to ensure the new group name is not empty or a duplicate of another groups' name.
- Created `renameGroup` function for the `useGroupStore`.
- Tweaked styling of headers. There was interaction between the `GroupDetails` and `EditGroupName` components which were each displaying an `h2`.