### PR TITLE
Background Update Handling

### DIFF
--- a/src/Common/Utilities/verifyContent.js
+++ b/src/Common/Utilities/verifyContent.js
@@ -1,0 +1,15 @@
+export default async function verifyContent(url, contentPrefix) {
+  try {
+    new URL(url); // throws if string cannot be parsed as a URL
+    const response = await fetch(url);
+    if (
+      !response.ok ||
+      !response.headers.get("Content-Type").startsWith(contentPrefix)
+    ) {
+      throw new Error();
+    }
+  } catch (e) {
+    return false;
+  }
+  return true;
+}

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -6,6 +6,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 
 import NavClose from "../Common/NavClose/NavClose";
+import PopUpModal from "../Common/PopUpModal/PopUpModal";
 import useRenderStore from "../Stores/useRenderStore";
 
 import "./Settings.css";
@@ -34,14 +35,17 @@ export function Settings({ getData }) {
   const {
     backgroundUrlInputValue,
     clearCache,
+    clearPopUp,
     configUrlInputValue,
     environment,
     handleConfigRefresh,
     handleConfigUrlChange,
     handleBackgroundUrlChange,
-    handleSetBakcground,
+    handleSetBackground,
+    popUpMessage,
     promptDownload,
     setShowSettings,
+    showPopUp,
     timeEnabled,
     timeFormat,
     updateSetting,
@@ -88,7 +92,7 @@ export function Settings({ getData }) {
             value={backgroundUrlInputValue}
             onChange={handleBackgroundUrlChange}
           />
-          <button id="applyBackgroundButton" onClick={handleSetBakcground}>
+          <button id="applyBackgroundButton" onClick={handleSetBackground}>
             Apply Background
           </button>
         </div>
@@ -104,6 +108,16 @@ export function Settings({ getData }) {
           updateSetting={updateSetting}
         />
       </div>
+      {showPopUp && (
+        <PopUpModal onBlur={clearPopUp}>
+          <p>{popUpMessage}</p>
+          <div className="butonBox">
+            <button className="green" onClick={clearPopUp}>
+              OK
+            </button>
+          </div>
+        </PopUpModal>
+      )}
     </>
   );
 }

--- a/src/Settings/useSettings.js
+++ b/src/Settings/useSettings.js
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+
 import useSettingStore from "../Stores/useSettingStore";
 import useRenderStore from "../Stores/useRenderStore";
 import useGroupStore from "../Stores/useGroupStore";
+import verifyContent from "../Common/Utilities/verifyContent";
 
 function useSettings(getData) {
   const [background, configUrl, timeEnabled, timeFormat, updateSetting] =
@@ -18,6 +20,8 @@ function useSettings(getData) {
   const [configUrlInputValue, setConfigUrlInputValue] = useState(configUrl);
   const [backgroundUrlInputValue, setBackgroundUrlInputValue] =
     useState(background);
+  const [showPopUp, setShowPopUp] = useState(false);
+  const [popUpMessage, setPopUpMessage] = useState("");
   const environment = process.env.REACT_APP_ENVIRONMENT || "production";
 
   useEffect(() => {
@@ -43,8 +47,21 @@ function useSettings(getData) {
     setBackgroundUrlInputValue(newUrl);
   };
 
-  const handleSetBakcground = () => {
-    updateSetting("background", backgroundUrlInputValue);
+  const handleSetBackground = async () => {
+    if (await verifyContent(backgroundUrlInputValue, "image")) {
+      updateSetting("background", backgroundUrlInputValue);
+      setPopUpMessage("Background updated successfully!");
+    } else {
+      setPopUpMessage(
+        `The URL provided did not lead to a valid image: ${backgroundUrlInputValue}`,
+      );
+    }
+    setShowPopUp(true);
+  };
+
+  const clearPopUp = () => {
+    setShowPopUp(false);
+    setPopUpMessage("");
   };
 
   const promptDownload = () => {
@@ -74,14 +91,17 @@ function useSettings(getData) {
   return {
     backgroundUrlInputValue,
     clearCache,
+    clearPopUp,
     configUrlInputValue,
     environment,
     handleConfigRefresh,
     handleConfigUrlChange,
     handleBackgroundUrlChange,
-    handleSetBakcground,
+    handleSetBackground,
+    popUpMessage,
     promptDownload,
     setShowSettings,
+    showPopUp,
     timeEnabled,
     timeFormat,
     updateSetting,


### PR DESCRIPTION
## Summary

This PR addresses Issue #72 which requests error-handling and success-confirmation when a user updates the background image URL.

## Changes

- Created a `verifyContent` utility function that tests that the response from a URL is of the expected `content-type`. This way I can ensure that I'm not updating the background URL until I'm certain it resolves to a usable image, ensuring no updates on failure.
- Added a `PopUpModal` that appears upon success or failure of the update action. This `PopUpModal` and its `popUpMessage` could be used to confirm any other update actions in the `Settings` view.
- Updated `handleSetBackground` to incorporate the check with `verifyContent` before proceeding with any updates.