### PR TITLE
Style Update

### DIFF
--- a/src/GroupTabs/groupTabs.css
+++ b/src/GroupTabs/groupTabs.css
@@ -24,6 +24,7 @@
   background: rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(5px);
   font-family: "Oxygen Mono", monospace;
+  text-shadow: 0 0 5px black;
 }
 
 .selectedGroup {
@@ -33,4 +34,5 @@
 .tabOptions {
   display: inline;
   margin: 0 5px 0 10px;
+  filter: drop-shadow(0 0 4px black);
 }

--- a/src/Settings/Settings.css
+++ b/src/Settings/Settings.css
@@ -1,8 +1,6 @@
 .Settings h1 {
   color: white;
   font-size: 24px;
-  margin-bottom: 20px;
-  margin-left: 20px;
 }
 
 .Settings h2 {

--- a/src/Settings/Settings.js
+++ b/src/Settings/Settings.js
@@ -55,7 +55,9 @@ export function Settings({ getData }) {
     <>
       <NavClose onClose={() => setShowSettings(false)} />
       <div className="Settings">
-        <h1>Settings</h1>
+        <div>
+          <h1>Settings</h1>
+        </div>
         <div>
           <h2>Config File URL</h2>
           <input


### PR DESCRIPTION
## Summary

This PR is a small change to update styling of `GroupTabs` for lighter backgrounds. This is a holdover until further Theme customizing options are implemented.

## Changes

- Used `text-shadow` on the `GroupTab` text and a `drop-shadow` on the FontAwesome icon. 
- The header for the `Settings` view was placed in a `div` to give it the smokey glass chiclet look of the other settings modules.