### PR TITLE
Trim Whitespace on Group Names

### DIFF
--- a/src/Group/EditGroupName/EditGroupName.js
+++ b/src/Group/EditGroupName/EditGroupName.js
@@ -16,7 +16,9 @@ function useEditGroupName(groupName) {
   const [restrictRename, setRestrictRename] = useState(true);
 
   const handleNameSave = () => {
-    renameGroup(groupName, tempName);
+    const trimmedNewName = tempName.trim();
+    setTempName(trimmedNewName);
+    renameGroup(groupName, trimmedNewName);
     setShowEdit(false);
   };
 
@@ -30,7 +32,7 @@ function useEditGroupName(groupName) {
     if (newName === "") {
       createButton.title = "Name cannot be empty";
       setRestrictRename(true);
-    } else if (existingNames.includes(newName)) {
+    } else if (existingNames.includes(newName.trim())) {
       createButton.title = "Name already exists";
       setRestrictRename(true);
     } else {


### PR DESCRIPTION
## Summary

This PR addresses Issue #79 which requests that user input for group names have trimming of whitespace at the beginning and end of the input string. 

## Changes

- Added check to `handleInputChange` to check if the trimmed string is a match for a duplicate group name. Ensuring that it cannot be saved if it is a duplicate after trimming.
- Updated `handleSaveName` to trim the input, save it to `tempName` in case another rename action is taken, and saves only the `trimmedNewName`.